### PR TITLE
Add schema version tagging to events for ordered upgrade handling

### DIFF
--- a/docs/adr/009-mandatory-schema-upgrade.md
+++ b/docs/adr/009-mandatory-schema-upgrade.md
@@ -24,9 +24,11 @@ A client may sync data only while its cached schema version matches the server's
 
 **Notification.** When the server commits a schema change, it broadcasts a `schema_changed` message over the WebSocket (ADR-013) to all connected clients for that tenant. Offline or disconnected clients discover the mismatch on their next HTTP sync attempt.
 
+**Per-event schema-version tagging.** `schema_changed` lives outside the event log and has no `seq`, so its delivery cannot be strictly ordered against in-flight event broadcasts that carry post-change `seq` values. To make ordering non-load-bearing, every event the server broadcasts is tagged with the `schema_version` that was active when the event was accepted (ADR-013). The client gates application on that tag: any event with `schema_version > active_schema_version` is held in a post-change buffer rather than applied or rejected. Whichever signal arrives first — the explicit `schema_changed` notification or a tagged post-change event — drives the client into blocked state and the same upgrade flow. After the user accepts the upgrade, buffered events are applied (or surfaced as part of the same reconciliation pass that handles pending local events).
+
 **Blocked state.** While blocked, the client:
 - Stops sending events to the server
-- Does not receive events from the server (the WebSocket remains open for `schema_changed` and heartbeats but carries no event traffic)
+- Stops applying events from the server: any in-flight events tagged with a newer `schema_version` are held in a post-change buffer rather than applied to projections or rejected (the WebSocket remains open for `schema_changed` and heartbeats)
 - Allows the user to continue generating events locally; local events accumulate in the pending-event queue
 - Displays a non-intrusive UI affordance indicating a schema upgrade is available
 
@@ -37,11 +39,12 @@ A client may sync data only while its cached schema version matches the server's
 4. Events referencing removed or incompatibly-changed fields are surfaced to the user for reconciliation (keep as note, discard, or map to a different field)
 5. Surviving pending events are sent; server acknowledges
 6. Client's `active_schema_version` is updated to the server's current version
-7. UI re-renders against the new schema
+7. Buffered post-change events (those tagged with the new version that arrived during the block) are now applied in `seq` order
+8. UI re-renders against the new schema
 
 **Pending-event reconciliation.** The flush of pending events must happen under the new schema, not the old. Local events generated before the upgrade are not automatically valid; they are subject to the validation pass in step 3. Reconciliation is a user-level decision — the user chooses what to do with events whose target has changed meaning.
 
-**Transport behavior during block.** The WebSocket remains connected during block state. Only `schema_changed` notifications and heartbeats traverse it. Events in either direction are suspended until upgrade accept.
+**Transport behavior during block.** The WebSocket remains connected during block state. `schema_changed` notifications and heartbeats traverse it as usual. The server may also continue to deliver post-change event broadcasts; these are tagged with the new `schema_version` and held in the client's post-change buffer rather than applied. Outbound events from the client are suspended until upgrade accept.
 
 ## Consequences
 
@@ -56,3 +59,5 @@ Schema changes propagate in near-real time to connected clients via WebSocket no
 The upgrade diff UX is load-bearing. Users need a clear view of what changed (fields added, removed, renamed) and what it means for their pending events. `introduced_in_version` and `removed_in_version` columns on field rows support this diff computation. Changes across multiple versions compact to a single effective diff; users upgrading from N to N+5 see one net change, not five sequential ones.
 
 A client offline for an extended period may return to find the schema has advanced several versions. The upgrade flow handles this transparently — the diff is still computed between the client's `active_schema_version` and the server's current version regardless of how many intermediate versions existed.
+
+Tagging events with their accepted `schema_version` and gating client application on it removes the need to order `schema_changed` against in-flight event broadcasts. The server can commit a schema change between events N and N+1 without coordinating fan-out timing: the client correctly blocks and buffers regardless of which message arrives first. The invariant "every accepted event was valid against the schema at acceptance time" remains a server-side property; the client now has a corresponding invariant — "no event is applied against a schema version other than the one it was accepted under" — which is what makes the server invariant useful end-to-end.

--- a/docs/adr/013-http-and-websocket-transports.md
+++ b/docs/adr/013-http-and-websocket-transports.md
@@ -56,9 +56,9 @@ Events with `seq <= gap_target` are covered by the gap-close query; events with 
 { "type": "ping" }
 
 // Server -> client
-{ "type": "welcome", "server_seq": N }
-{ "type": "event", "seq": N, "event": { ... } }
-{ "type": "ack", "event_id": "...", "seq": N,
+{ "type": "welcome", "server_seq": N, "schema_version": V }
+{ "type": "event", "seq": N, "schema_version": V, "event": { ... } }
+{ "type": "ack", "event_id": "...", "seq": N, "schema_version": V,
   "status": "applied" | "rejected", "reason": "..." }
 { "type": "schema_changed", "version": V }
 { "type": "pong" }
@@ -70,11 +70,13 @@ The `event_id` on client-sent messages is a client-generated identifier for the 
 
 **Broadcast ordering.** Server fan-out happens after the event is committed to the log, never inside the transaction. Broadcasts are sent in `seq` order — a single broadcaster task reads new log entries in order and fans them out to relevant tenant subscribers. This decouples commit from fan-out and guarantees ordered delivery to every subscriber.
 
+**Schema version tagging on events.** Every event broadcast (over WebSocket or HTTP) carries the `schema_version` that was active on the server when the event was accepted. `schema_changed` lives outside the event log and has no `seq`, so its ordering relative to in-flight event broadcasts is not guaranteed. Rather than enforce that ordering, clients gate event application on `schema_version`: any received event with `schema_version > active_schema_version` is buffered locally and held until the client transitions through the upgrade flow (ADR-009). This makes the delivery order of `schema_changed` non-load-bearing — a client that receives a post-change event before the `schema_changed` notification arrives at the same conclusion (block, prompt for upgrade) via the version mismatch on the event itself.
+
 **Heartbeats and dead connections.** Client sends `ping` every 20-30 seconds. Server treats a subscriber as dead if no `ping` has arrived in 60 seconds, closes the WebSocket, and removes the subscriber from the registry. Both sides implement reconnection with exponential backoff (1s, 2s, 4s, ..., capped at 30s).
 
 **Reconnection.** On WebSocket close the client starts backoff. If the socket has been down for more than roughly 30 seconds on reconnect, the client does an HTTP `/sync` first to catch up efficiently, then opens a new WebSocket from the updated cursor. Short drops can reconnect and resume directly.
 
-**Schema change notifications.** When the server commits a schema change, it broadcasts `schema_changed` to all connected subscribers of the affected tenant. Clients transition to blocked state (ADR-009). The WebSocket remains open but no events flow in either direction until the client's `active_schema_version` catches up.
+**Schema change notifications.** When the server commits a schema change, it broadcasts `schema_changed` to all connected subscribers of the affected tenant. Clients transition to blocked state (ADR-009). The WebSocket remains open but no events flow in either direction until the client's `active_schema_version` catches up. A client may also discover the change via the `schema_version` tag on a delivered event arriving before `schema_changed`; the response is the same (block, hold post-change events, prompt the user to accept the upgrade).
 
 **Transport interchangeability.** The wire format of an event is identical regardless of transport. The HTTP endpoint is not a fallback with a different protocol — it is the same protocol over a different pipe. We should routinely test with WebSocket disabled to ensure the application remains functional on pure HTTP, as corporate proxies and some browser configurations block WebSocket upgrades.
 


### PR DESCRIPTION
## Summary

This change enhances the schema upgrade mechanism by tagging all events with their accepted `schema_version` and using that tag to gate client-side event application. This removes the need to strictly order `schema_changed` notifications against in-flight event broadcasts, making the upgrade flow more robust.

## Key Changes

- **Per-event schema version tagging**: All events broadcast over WebSocket or HTTP now carry the `schema_version` active when the event was accepted on the server
  - Updated wire format in ADR-013 to include `schema_version` field on `welcome`, `event`, and `ack` messages
  
- **Client-side event buffering**: Clients now gate event application on the `schema_version` tag
  - Events with `schema_version > active_schema_version` are held in a post-change buffer rather than applied or rejected
  - This buffer is processed after the user accepts the schema upgrade
  
- **Decoupled notification ordering**: The delivery order of `schema_changed` notifications is no longer load-bearing
  - Clients can discover schema changes either via explicit `schema_changed` message or by receiving an event tagged with a newer schema version
  - Both paths trigger the same blocked state and upgrade flow
  
- **Updated blocked state behavior**: While blocked, clients now continue to receive post-change events but hold them in a buffer instead of applying them
  - WebSocket remains open for `schema_changed` notifications, heartbeats, and post-change event broadcasts
  - Only outbound events from the client are suspended

## Implementation Details

- The server maintains the invariant: "every accepted event was valid against the schema at acceptance time"
- The client now maintains a corresponding invariant: "no event is applied against a schema version other than the one it was accepted under"
- Buffered post-change events are applied in `seq` order after upgrade acceptance, ensuring consistency
- This approach handles multi-version upgrades transparently — clients upgrading across several versions see a single effective diff

https://claude.ai/code/session_01WymAv3BcM3ZQ4N1gNTN2sA