### PR TITLE
Update ADR statuses from proposed to accepted

### DIFF
--- a/docs/adr/001-overall-architecture.md
+++ b/docs/adr/001-overall-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/002-event-sourcing-the-sync-backbone.md
+++ b/docs/adr/002-event-sourcing-the-sync-backbone.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/005-schema-as-data-with-json-projections.md
+++ b/docs/adr/005-schema-as-data-with-json-projections.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/011-append-only-event-log.md
+++ b/docs/adr/011-append-only-event-log.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/012-eav-events-with-json-projections.md
+++ b/docs/adr/012-eav-events-with-json-projections.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/014-multi-tenancy-model.md
+++ b/docs/adr/014-multi-tenancy-model.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/016-rfc9457-problem-details-error-envelope.md
+++ b/docs/adr/016-rfc9457-problem-details-error-envelope.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-05-03
 category: transport
 decision-makers: [Sam Caldwell]

--- a/docs/adr/016-rfc9457-problem-details-error-envelope.md
+++ b/docs/adr/016-rfc9457-problem-details-error-envelope.md
@@ -11,7 +11,7 @@ informed: []
 
 ## Context and Problem Statement
 
-The schema endpoint (ADR-013) currently returns errors as an ad-hoc JSON envelope (`{error, code, message, ...extras}`) — three top-level fields with overlapping concerns and untyped extension keys. As more endpoints come online they will all need an error contract; we'd rather not propagate the ad-hoc shape across the API. Should we adopt a standard error envelope, and if so which one?
+The schema endpoint (ADR-008) currently returns errors as an ad-hoc JSON envelope (`{error, code, message, ...extras}`) — three top-level fields with overlapping concerns and untyped extension keys. As more endpoints come online they will all need an error contract; we'd rather not propagate the ad-hoc shape across the API. Should we adopt a standard error envelope, and if so which one?
 
 ## Decision Drivers
 


### PR DESCRIPTION
## Summary
This PR updates the status of multiple Architecture Decision Records (ADRs) from "proposed" to "accepted", reflecting decisions that have been finalized and adopted.

## Key Changes
- Updated ADR-001 (Overall Architecture) status to accepted
- Updated ADR-002 (Event Sourcing the Sync Backbone) status to accepted
- Updated ADR-005 (Schema as Data with JSON Projections) status to accepted
- Updated ADR-011 (Append-only Event Log) status to accepted
- Updated ADR-012 (EAV Events with JSON Projections) status to accepted
- Updated ADR-014 (Multi-tenancy Model) status to accepted
- Updated ADR-016 (RFC9457 Problem Details Error Envelope) status to accepted
- Fixed reference in ADR-016 from ADR-013 to ADR-008 in the problem statement

## Notable Details
These status updates indicate that the architectural decisions documented in these ADRs have been reviewed, approved, and are now in effect. The correction of the ADR reference in ADR-016 ensures consistency and accuracy in cross-document citations.

https://claude.ai/code/session_01GGXc2HcctcZoobw5EJ65AN