### PR TITLE
chore(tests): silence advanced-alchemy set_async_context DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,11 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 addopts = "-ra"
+filterwarnings = [
+    # advanced-alchemy 1.9.x calls its own deprecated `set_async_context()`
+    # from the Litestar plugin's `provide_session` (and other framework
+    # extensions). The function is a no-op stub that only warns; the call
+    # site is still on `main` upstream and there's no tracking issue yet.
+    # Drop this entry once advanced-alchemy ships a fix and we upgrade.
+    "ignore:Call to deprecated function 'set_async_context'.*:DeprecationWarning:advanced_alchemy._listeners",
+]


### PR DESCRIPTION
## Summary

- Add a narrowly-scoped `filterwarnings` entry in `pyproject.toml` to silence the `DeprecationWarning` advanced-alchemy 1.9.x emits on every Litestar request.
- Filter is matched on both message **and** emitting module (`advanced_alchemy._listeners`), so unrelated `DeprecationWarning`s still surface.

## Context

`advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py:264` calls `set_async_context(True)` inside `provide_session()` on every request. `set_async_context` (in `advanced_alchemy/_listeners.py:110-122`) is a no-op stub deprecated in 1.9.0 — the library is calling its own deprecated function. Result: 35 identical `DeprecationWarning`s in our suite (1 + 11 + 23 in the request-driven tests).

Upstream status (as of 2026-05-05):

- 1.9.3 is the latest published version.
- No open issue or PR tracks the warning.
- The call site is still present on advanced-alchemy `main`.
- PR [#643](https://github.com/litestar-org/advanced-alchemy/pull/643) (merged 2025-12-20) actually *adds* another caller of the deprecated function in the Sanic extension — the deprecation appears premature.

The pyproject comment notes that this entry should be dropped once advanced-alchemy ships a fix and we upgrade.

## Test plan

- [x] `uv run pytest` → `135 passed`, no warnings summary section.
- [x] `just check` (lint + format + typecheck + test) → clean.
- [x] Filter scope verified: matches `set_async_context` warning from `advanced_alchemy._listeners` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)