### PR TITLE
refactor(accounts): return str from resolve_tenant

### DIFF
--- a/src/py/novamoc/domain/accounts/_middleware.py
+++ b/src/py/novamoc/domain/accounts/_middleware.py
@@ -18,6 +18,7 @@ Configured at app construction with the OpenAPI doc bypass:
 """
 
 from __future__ import annotations
+from novamoc.domain.accounts import RequestAuth
 
 from typing import TYPE_CHECKING
 
@@ -36,5 +37,5 @@ class AuthenticationMiddleware(AbstractAuthenticationMiddleware):
     async def authenticate_request(
         self, connection: ASGIConnection
     ) -> AuthenticationResult:
-        auth = resolve_tenant(connection.headers)
-        return AuthenticationResult(user=None, auth=auth)
+        tenant_id = resolve_tenant(connection.headers)
+        return AuthenticationResult(user=None, auth=RequestAuth(tenant_id=tenant_id))

--- a/src/py/novamoc/domain/accounts/_resolver.py
+++ b/src/py/novamoc/domain/accounts/_resolver.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from novamoc.domain.accounts._auth import RequestAuth
 from novamoc.domain.accounts._errors import TenantResolutionError
 
 if TYPE_CHECKING:
@@ -24,11 +23,13 @@ if TYPE_CHECKING:
 # the trust model for the dev period (ADR-017). Replaced by a real per-tenant
 # token registry — see issue #19.
 _TENANT_T1_DEV_TOKEN = "t1-dev-token"
+_TENANT_T1 = "t1"
+
 _BEARER_PREFIX = "Bearer "
 
 
-def resolve_tenant(headers: Headers) -> RequestAuth:
-    """Return the ``RequestAuth`` for this request, or raise.
+def resolve_tenant(headers: Headers) -> str:
+    """Return the tenant ID for this request, or raise.
 
     Raises:
         TenantResolutionError: when the ``Authorization`` header is missing,
@@ -40,4 +41,4 @@ def resolve_tenant(headers: Headers) -> RequestAuth:
     token = value[len(_BEARER_PREFIX) :]
     if token != _TENANT_T1_DEV_TOKEN:
         raise TenantResolutionError()
-    return RequestAuth(tenant_id="t1")
+    return _TENANT_T1

--- a/tests/accounts/test_resolver.py
+++ b/tests/accounts/test_resolver.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 import pytest
 from litestar.datastructures import Headers
 
-from novamoc.domain.accounts import RequestAuth, TenantResolutionError
+from novamoc.domain.accounts import TenantResolutionError
 
 
 def test_valid_bearer_returns_t1_context() -> None:
-    from novamoc.domain.accounts._resolver import _TENANT_T1_DEV_TOKEN, resolve_tenant
+    from novamoc.domain.accounts._resolver import (
+        _TENANT_T1_DEV_TOKEN,
+        _TENANT_T1,
+        resolve_tenant,
+    )
 
     headers = Headers({"authorization": f"Bearer {_TENANT_T1_DEV_TOKEN}"})
-    assert resolve_tenant(headers) == RequestAuth(tenant_id="t1")
+    assert resolve_tenant(headers) == _TENANT_T1
 
 
 def test_missing_authorization_header_raises() -> None:


### PR DESCRIPTION
Previously returned a RequestAuth object but it is the job of the caller
(AuthenticationMiddleware.authenticate_request) to build the RequestAuth
object.
