### PR TITLE
feat(events): schema-version gate on POST /events

### DIFF
--- a/docs/problems/schema_version_stale.md
+++ b/docs/problems/schema_version_stale.md
@@ -1,0 +1,34 @@
+The batch's `schema_version` does not match the tenant's current
+schema version on the server. Schema upgrades are mandatory (ADR-009):
+events authored against an old schema can reference fields that have
+been deleted, or miss fields that the new schema requires, so the
+server refuses the whole batch rather than risk a malformed
+projection.
+
+The response carries two extension members:
+
+- `expected` — the tenant's current `schema_version` on the server.
+- `received` — the `schema_version` the client sent on the batch.
+
+## Common causes
+
+- The client's locally cached schema is older than the server's. A
+  concurrent `POST /schema` from another session has advanced the
+  version since the client last fetched the schema.
+- The client started the batch before catching up to a schema change
+  it has already observed elsewhere.
+
+## How to fix
+
+- Re-read the schema via `GET /schema`; its `schema_version` is the
+  value the next batch must carry. Apply any local consequences of
+  the new schema (e.g., drop pending edits that reference deleted
+  fields).
+- Resubmit the batch with the refreshed `schema_version`. Past-dated
+  HLCs remain valid (per ADR-006) so the original event ordering is
+  preserved.
+
+## Related
+
+- ADR-008 — schema is server-authoritative; clients are followers.
+- ADR-009 — mandatory schema upgrade and the catch-up flow.

--- a/src/py/novamoc/api/_problem_details.py
+++ b/src/py/novamoc/api/_problem_details.py
@@ -49,6 +49,7 @@ _TITLES: dict[ErrorCode, str] = {
     ErrorCode.PARENT_TYPE_NOT_FOUND: "Parent type not found",
     ErrorCode.ENTITY_NOT_FOUND: "Entity not found",
     ErrorCode.HLC_DRIFT_EXCEEDED: "HLC drift exceeded",
+    ErrorCode.SCHEMA_VERSION_STALE: "Schema version stale",
 }
 
 
@@ -59,6 +60,7 @@ _STATUS_CODES: dict[ErrorCode, int] = {
     ErrorCode.PARENT_TYPE_NOT_FOUND: 409,
     ErrorCode.ENTITY_NOT_FOUND: 404,
     ErrorCode.HLC_DRIFT_EXCEEDED: 400,
+    ErrorCode.SCHEMA_VERSION_STALE: 409,
 }
 
 

--- a/src/py/novamoc/domain/_errors.py
+++ b/src/py/novamoc/domain/_errors.py
@@ -20,6 +20,7 @@ class ErrorCode(StrEnum):
     PARENT_TYPE_NOT_FOUND = "parent_type_not_found"
     ENTITY_NOT_FOUND = "entity_not_found"
     HLC_DRIFT_EXCEEDED = "hlc_drift_exceeded"
+    SCHEMA_VERSION_STALE = "schema_version_stale"
 
 
 _DEFAULT_MESSAGES: dict[ErrorCode, str] = {
@@ -32,6 +33,9 @@ _DEFAULT_MESSAGES: dict[ErrorCode, str] = {
     ErrorCode.ENTITY_NOT_FOUND: "Entity not found.",
     ErrorCode.HLC_DRIFT_EXCEEDED: (
         "Event HLC physical clock is too far ahead of the server's wall clock."
+    ),
+    ErrorCode.SCHEMA_VERSION_STALE: (
+        "Batch schema_version does not match the tenant's current schema version."
     ),
 }
 

--- a/src/py/novamoc/domain/events/_errors.py
+++ b/src/py/novamoc/domain/events/_errors.py
@@ -22,3 +22,21 @@ class HLCDriftExceededError(DomainError):
             drift_seconds=drift_seconds,
             limit_seconds=limit_seconds,
         )
+
+
+class SchemaVersionStaleError(DomainError):
+    """Batch's ``schema_version`` does not match the tenant's current
+    schema version (ADR-008 / ADR-009).
+
+    Schema upgrades are mandatory: events generated against a stale
+    schema cannot be safely folded into a projection that has since
+    evolved, so the server refuses them and the client must re-fetch
+    the schema before retrying.
+    """
+
+    def __init__(self, *, expected: int, received: int) -> None:
+        super().__init__(
+            code=ErrorCode.SCHEMA_VERSION_STALE,
+            expected=expected,
+            received=received,
+        )

--- a/src/py/novamoc/domain/events/controllers/_events.py
+++ b/src/py/novamoc/domain/events/controllers/_events.py
@@ -1,20 +1,27 @@
 """HTTP controller for ``/events`` (ADR-013).
 
-M1.2 adds HLC parse + drift-bound validation. Each event's ``hlc``
-is parsed into a structured :class:`HLC`; an HLC whose physical
-component sits more than ``AppSettings.hlc_drift_limit_seconds``
-ahead of the server's wall clock is rejected at acceptance time as
-``hlc_drift_exceeded``. Drift is one-sided per ADR-006 — past HLCs
-are always accepted; only the future side carries the honesty risk
-for forged client timestamps.
+The handler enforces two pre-persistence gates before the batch is
+accepted:
 
-Persistence, projection writes, and schema-version gating land in
-M1.3+; this controller currently returns ``202 Accepted`` for every
-event that survives parsing and the drift check.
+* Schema-version gate (M1.3, ADR-008 / ADR-009): the batch's
+  ``schema_version`` must equal the tenant's current schema
+  version. A mismatch is rejected as ``schema_version_stale`` (409)
+  so the projection fold never sees events authored against a
+  schema the server has since evolved past.
+* HLC validation (M1.2, ADR-006): each event's ``hlc`` is parsed
+  into a structured :class:`HLC`; an HLC whose physical component
+  sits more than ``AppSettings.hlc_drift_limit_seconds`` ahead of
+  the server's wall clock is rejected as ``hlc_drift_exceeded``.
+  Past HLCs are always accepted — drift is one-sided.
+
+Persistence and projection writes land in M1.5+; this controller
+currently returns ``202 Accepted`` for every batch that survives
+both gates.
 """
 
 from __future__ import annotations
 
+from advanced_alchemy.extensions.litestar import providers
 from litestar import Controller, post
 from litestar.datastructures import (
     State,  # noqa: TC002  # runtime DI provider annotation
@@ -24,8 +31,12 @@ from litestar.exceptions import ValidationException
 from litestar.status_codes import HTTP_202_ACCEPTED
 
 from novamoc.domain.events import _payloads
-from novamoc.domain.events._errors import HLCDriftExceededError
+from novamoc.domain.events._errors import (
+    HLCDriftExceededError,
+    SchemaVersionStaleError,
+)
 from novamoc.domain.events._hlc import HLC, HLCParseError, wall_now_ms
+from novamoc.domain.schema.services import SchemaChangeLogService
 
 
 async def _provide_drift_limit_seconds(state: State) -> float:
@@ -35,19 +46,31 @@ async def _provide_drift_limit_seconds(state: State) -> float:
 class EventsController(Controller):
     path = "/events"
     tags = ("events",)
-    dependencies = {  # noqa: RUF012
-        "drift_limit_seconds": Provide(_provide_drift_limit_seconds),
-    }
+    dependencies = {
+        "drift_limit_seconds": Provide(_provide_drift_limit_seconds)
+    } | providers.create_service_dependencies(
+        SchemaChangeLogService, "schema_change_log_service"
+    )
 
     @post("/", status_code=HTTP_202_ACCEPTED)
     async def append(
         self,
         data: _payloads.EventBatch,
         drift_limit_seconds: float,
+        schema_change_log_service: SchemaChangeLogService,
     ) -> None:
+        # Schema-version gate runs before HLC parsing so a stale-
+        # schema client gets the actionable error (re-fetch /schema)
+        # instead of a secondary HLC complaint.
+        current_version = await schema_change_log_service.current_version()
+        if data.schema_version != current_version:
+            raise SchemaVersionStaleError(
+                expected=current_version,
+                received=data.schema_version,
+            )
+
         # One server-now read covers the whole batch so an event at
-        # the edge of the budget can't get re-checked against a later
-        # server time mid-iteration.
+        # the edge of the budget isn't re-checked mid-iteration.
         server_now_ms = wall_now_ms()
         limit_ms = int(drift_limit_seconds * 1000)
 
@@ -55,8 +78,6 @@ class EventsController(Controller):
             try:
                 parsed = HLC.parse(event.hlc)
             except HLCParseError as exc:
-                # Reaches the invalid_payload_shape converter — same
-                # shape as any other malformed body.
                 raise ValidationException(detail=str(exc)) from exc
 
             drift_ms = parsed.physical_ms - server_now_ms

--- a/tests/events/test_endpoint_drift.py
+++ b/tests/events/test_endpoint_drift.py
@@ -53,7 +53,7 @@ def settings() -> Settings:
 async def test_past_hlc_is_accepted(client: AsyncTestClient) -> None:
     resp = await client.post(
         "/events",
-        json={"schema_version": 1, "events": [_event(_PAST_HLC)]},
+        json={"schema_version": 0, "events": [_event(_PAST_HLC)]},
     )
     assert resp.status_code == 202, resp.text
 
@@ -63,7 +63,7 @@ async def test_far_future_hlc_is_rejected_as_drift_exceeded(
 ) -> None:
     resp = await client.post(
         "/events",
-        json={"schema_version": 1, "events": [_event(_FAR_FUTURE_HLC)]},
+        json={"schema_version": 0, "events": [_event(_FAR_FUTURE_HLC)]},
     )
     assert resp.status_code == 400, resp.text
     body = resp.json()
@@ -80,7 +80,7 @@ async def test_malformed_hlc_is_rejected_as_invalid_payload_shape(
 ) -> None:
     resp = await client.post(
         "/events",
-        json={"schema_version": 1, "events": [_event("not-an-hlc")]},
+        json={"schema_version": 0, "events": [_event("not-an-hlc")]},
     )
     assert resp.status_code == 400, resp.text
     body = resp.json()
@@ -96,7 +96,7 @@ async def test_first_bad_event_rejects_whole_batch(
     resp = await client.post(
         "/events",
         json={
-            "schema_version": 1,
+            "schema_version": 0,
             "events": [
                 _event(_PAST_HLC),
                 _event(_FAR_FUTURE_HLC),

--- a/tests/events/test_endpoint_scaffold.py
+++ b/tests/events/test_endpoint_scaffold.py
@@ -9,7 +9,7 @@ async def test_post_events_returns_202_for_valid_batch(client) -> None:
     resp = await client.post(
         "/events",
         json={
-            "schema_version": 1,
+            "schema_version": 0,
             "events": [
                 {
                     "hlc": "0001700000000000-00000-abc",
@@ -32,6 +32,6 @@ async def test_post_events_accepts_empty_batch(client) -> None:
     # and explicitly defers all validation to later milestones (M1.2+).
     resp = await client.post(
         "/events",
-        json={"schema_version": 1, "events": []},
+        json={"schema_version": 0, "events": []},
     )
     assert resp.status_code == 202, resp.text

--- a/tests/events/test_endpoint_schema_version.py
+++ b/tests/events/test_endpoint_schema_version.py
@@ -1,0 +1,117 @@
+"""Schema-version gate tests for ``POST /events`` (M1.3, ADR-008/009).
+
+A batch's ``schema_version`` must equal the tenant's current schema
+version. The gate runs ahead of HLC parsing so a stale-schema client
+gets the actionable error (re-fetch ``GET /schema``) rather than a
+secondary HLC-format complaint.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from litestar.testing import AsyncTestClient
+
+
+_VALID_HLC = "0000000000000001-00000-client-a"
+
+
+def _event(hlc: str = _VALID_HLC) -> dict[str, object]:
+    return {
+        "hlc": hlc,
+        "family": "asset",
+        "type_id": str(uuid4()),
+        "instance_id": str(uuid4()),
+        "body": {"event": "created", "values": {"col:name": "x"}},
+    }
+
+
+async def _bump_schema_version(client: AsyncTestClient) -> int:
+    """Create one asset type via ``POST /schema``; return its server schema_version."""
+    resp = await client.post(
+        "/schema",
+        json={
+            "type": "create_asset_type",
+            "entity_id": str(uuid4()),
+            "payload": {"name": f"Truck-{uuid4()}"},
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return int(resp.json()["schema_version"])
+
+
+async def test_fresh_tenant_accepts_version_zero(client: AsyncTestClient) -> None:
+    resp = await client.post(
+        "/events",
+        json={"schema_version": 0, "events": [_event()]},
+    )
+    assert resp.status_code == 202, resp.text
+
+
+async def test_stale_version_rejected_as_409(client: AsyncTestClient) -> None:
+    version_after_create = await _bump_schema_version(client)
+    assert version_after_create == 1
+
+    resp = await client.post(
+        "/events",
+        json={"schema_version": 0, "events": [_event()]},
+    )
+    assert resp.status_code == 409, resp.text
+    body = resp.json()
+    assert body["type"] == "http://test/problems/schema_version_stale.html"
+    assert body["title"] == "Schema version stale"
+    assert body["status"] == 409
+    assert body["expected"] == 1
+    assert body["received"] == 0
+
+
+async def test_future_version_also_rejected(client: AsyncTestClient) -> None:
+    resp = await client.post(
+        "/events",
+        json={"schema_version": 99, "events": [_event()]},
+    )
+    assert resp.status_code == 409, resp.text
+    body = resp.json()
+    assert body["type"] == "http://test/problems/schema_version_stale.html"
+    assert body["expected"] == 0
+    assert body["received"] == 99
+
+
+async def test_matched_version_after_schema_change_is_accepted(
+    client: AsyncTestClient,
+) -> None:
+    version_after_create = await _bump_schema_version(client)
+    resp = await client.post(
+        "/events",
+        json={"schema_version": version_after_create, "events": [_event()]},
+    )
+    assert resp.status_code == 202, resp.text
+
+
+async def test_version_gate_runs_before_hlc_validation(
+    client: AsyncTestClient,
+) -> None:
+    # A stale-version batch should be rejected as schema_version_stale,
+    # not invalid_payload_shape — even if its events have malformed HLCs.
+    # The gate is the more actionable failure (re-fetch /schema) and the
+    # client cannot proceed past it anyway.
+    await _bump_schema_version(client)
+    resp = await client.post(
+        "/events",
+        json={"schema_version": 0, "events": [_event("not-an-hlc")]},
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["type"] == "http://test/problems/schema_version_stale.html"
+
+
+async def test_empty_batch_with_mismatched_version_still_rejected(
+    client: AsyncTestClient,
+) -> None:
+    await _bump_schema_version(client)
+    resp = await client.post(
+        "/events",
+        json={"schema_version": 0, "events": []},
+    )
+    assert resp.status_code == 409, resp.text


### PR DESCRIPTION
Closes #22.

## Summary
- M1.3 of the event-sync endpoint (closes #22, ADR-008/009). The controller compares the batch's `schema_version` against the tenant's current version (`SchemaChangeLogService.current_version()`) before HLC validation. A mismatch — stale or future — is rejected as `schema_version_stale` (409) with `expected` / `received` as RFC 9457 extension members.
- Gate intentionally runs ahead of HLC parsing so a stale-schema client sees the actionable error (re-fetch `/schema`) rather than a secondary HLC-format complaint.
- `EventsController` picks up `SchemaChangeLogService` via `advanced_alchemy.providers.create_service_dependencies` (same DI pattern as `SchemaController`).
- New `SchemaVersionStaleError(SchemaError)` subclass; existing problem-details converter handles it via subclass dispatch.
- New problem doc at `docs/problems/schema_version_stale.md`.
- Pre-existing event endpoint tests updated to `schema_version=0` (matching a fresh, unseeded tenant).

> ⚠️ Stacked on #62 (M1.2). Base will auto-retarget to `main` once #62 merges.

## Test plan
- [x] Fresh tenant accepts `schema_version=0` (202).
- [x] Stale `schema_version` → 409 + full problem-details envelope including `expected` / `received`.
- [x] Future `schema_version` rejected the same way.
- [x] Matched version after one schema change is accepted.
- [x] Gate fires before HLC validation (stale-version batch with malformed HLC reports schema_version_stale, not invalid_payload_shape).
- [x] Empty batch with mismatched version still rejected.
- [x] `just check` clean — 233 tests, ratchet at 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
