### PR TITLE
feat(events): append accepted events to event_log; per-event outcomes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,21 +131,26 @@ ETag = `"<schema_version>"` (RFC 7232 quoted decimal); `If-None-Match` matching 
 ## Events endpoint (`POST /events`)
 
 Companion to the schema endpoint and the only fully implemented write
-path for **data** events (ADR-002 / ADR-011 / ADR-013). The controller
-enforces three pre-persistence gates and then routes each event to its
-handler:
+path for **data** events (ADR-002 / ADR-011 / ADR-013). Batch-level
+failures (``schema_version_stale``, malformed body) reject the whole
+submission via ``application/problem+json``; per-event work is atomic
+at the event grain (M1.5) and surfaces as ``accepted`` / ``duplicate``
+/ ``rejected:<code>`` outcomes in the response.
+
+Controller responsibilities (all the controller does):
 
 1. **Schema-version gate** (batch-level, ADR-008 / ADR-009) — the
    batch's ``schema_version`` must equal the tenant's current schema
    version, or the whole batch is rejected as ``schema_version_stale``.
 2. **HLC parse + drift bound** (per-event, ADR-006) — each event's
    ``hlc`` is parsed; an HLC more than ``hlc_drift_limit_seconds`` ahead
-   of server wall time raises ``hlc_drift_exceeded``. Past HLCs are
-   always accepted.
-3. **Per-event handler dispatch** (M1.4) — each event is routed via
-   ``_HANDLERS[(event.family, type(event.body))]``; today the handlers
-   do field-existence + value-shape validation, M1.5+ layers persistence
-   and projection writes into the same cells.
+   of server wall time is rejected as
+   ``rejected:hlc_drift_exceeded``. Past HLCs are always accepted.
+3. **Dispatch + outcome aggregation** — each surviving event is routed
+   via ``_HANDLERS[(event.family, type(event.body))]``. The handler
+   validates and appends to ``event_log``; the controller catches any
+   ``DomainError`` it raises, maps it to ``rejected:<code>``, and
+   aggregates the per-event outcomes into the response.
 
 Pipeline mirrors the schema endpoint's shape:
 
@@ -154,26 +159,31 @@ Pipeline mirrors the schema endpoint's shape:
    ``Updated``, ``Deactivated``, ``Activated``) with msgspec's
    tag-field discrimination on ``event``.
 2. **Service bundle** — ``domain/events/_bundle.py`` aggregates the two
-   ``*TypeFieldService`` instances and owns a per-request memo
-   (``fields_for(family, type_id)``) so a batch with many events on one
-   type pays one ``SELECT`` for the field set.
+   ``*TypeFieldService`` instances, the ``EventLogService``, and the
+   batch's ``schema_version`` into one per-request object. Owns the
+   ``fields_for(family, type_id)`` memo (a batch with many events on
+   one type pays one ``SELECT``) and the ``append_event(event)`` helper
+   that does the savepoint-isolated ``event_log`` insert and returns
+   the ``accepted`` / ``duplicate`` outcome.
 3. **Dispatch** — ``_dispatch.py`` holds a single explicit ``_HANDLERS``
-   table keyed on ``(EntityFamily, type[EventBody])``. Adding an event
-   type or family requires one new handler module-level function plus
-   one row in the table.
+   table keyed on ``(EntityFamily, type[EventBody])``. Each handler
+   returns an ``EventOutcome``; adding an event type or family requires
+   one new handler module-level function plus one row in the table.
 4. **Handlers** — ``_handlers/{asset,maintenance_record}.py`` expose
-   ``created`` / ``updated`` / ``deactivated`` / ``activated``. M1.4
-   created/updated load the type's field set via
-   ``services.fields_for(...)`` and call the sync
-   ``validate_values(...)``; deactivated/activated are no-ops that hold
-   the cell open for M1.5+ persistence.
+   ``created`` / ``updated`` / ``deactivated`` / ``activated``. Each
+   returns an ``EventOutcome``. ``created``/``updated`` load the type's
+   field set via ``services.fields_for(...)``, run sync
+   ``validate_values(...)``, then call ``services.append_event(...)``;
+   ``deactivated``/``activated`` skip validation and just append.
 5. **Validators** — ``_validators.py`` exports one public sync entry
    point ``validate_values(event, values, fields_by_id)`` plus the
    ``matches_data_type`` / ``json_type_name`` predicates. The validator
    does no I/O; handlers feed it a preloaded field map.
 6. **Controller** — ``controllers/_events.py`` is thin: schema-version
-   gate, per-event HLC check, ``dispatch(services, auth, event)``. It
-   does **not** import ``_validators`` — that's the handler's concern.
+   gate, per-event HLC check, ``dispatch(services, auth, event)``,
+   catch ``DomainError`` → ``rejected:<code>``. It does **not** import
+   ``_validators`` and does **not** touch ``event_log`` directly — both
+   are the handler's concern.
 
 Errors flow through the same problem-details converter as the schema
 endpoint. Per-event error types live in ``domain/events/_errors.py``

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,14 @@ path for **data** events (ADR-002 / ADR-011 / ADR-013). Batch-level
 failures (``schema_version_stale``, malformed body) reject the whole
 submission via ``application/problem+json``; per-event work is atomic
 at the event grain (M1.5) and surfaces as ``accepted`` / ``duplicate``
-/ ``rejected:<code>`` outcomes in the response.
+/ ``rejected:<code>`` outcomes in the response. Rejected outcomes
+additionally carry ``problem``, a dict shaped like the
+``application/problem+json`` body the same error would produce at
+batch level — standard RFC 9457 slots (``type``, ``title``, ``status``,
+``detail``, ``instance``) plus per-code extension members at top level
+(``drift_seconds``, ``field``, ``expected``, ...). ``api/_problem_details.make_problem_body``
+builds it and is shared with the batch-level converter so the wire
+shape is identical.
 
 Controller responsibilities (all the controller does):
 
@@ -181,9 +188,13 @@ Pipeline mirrors the schema endpoint's shape:
    does no I/O; handlers feed it a preloaded field map.
 6. **Controller** — ``controllers/_events.py`` is thin: schema-version
    gate, per-event HLC check, ``dispatch(services, auth, event)``,
-   catch ``DomainError`` → ``rejected:<code>``. It does **not** import
-   ``_validators`` and does **not** touch ``event_log`` directly — both
-   are the handler's concern.
+   catch ``DomainError`` → ``rejected:<code>`` (with the problem body
+   built by ``make_problem_body``). The HLC parse and drift-exceeded
+   paths funnel through the same conversion by raising
+   ``PayloadShapeError`` / ``HLCDriftExceededError`` rather than
+   building outcomes inline. The controller does **not** import
+   ``_validators`` and does **not** touch ``event_log`` directly —
+   both are the handler's concern.
 
 Errors flow through the same problem-details converter as the schema
 endpoint. Per-event error types live in ``domain/events/_errors.py``

--- a/docs/problems/hlc_drift_exceeded.md
+++ b/docs/problems/hlc_drift_exceeded.md
@@ -4,12 +4,19 @@ server rejects these events at acceptance time so a single client with
 a badly-set clock cannot push the shared HLC state arbitrarily far into
 the future (ADR-006).
 
-The response carries three extension members:
+The problem body carries three extension members:
 
 - `hlc` — the rejected HLC string, as submitted.
 - `drift_seconds` — how far ahead of the server the HLC's physical
   component sits.
 - `limit_seconds` — the server's configured drift bound.
+
+On `/events` the rejection arrives as a per-event entry in the
+response's `outcomes` array: `outcome` is `rejected:hlc_drift_exceeded`
+and the standard slots + extras above ride at the top of
+`outcomes[i].problem`. The HTTP status is the batch envelope's `202`;
+`problem.status` carries the `400` this rejection would surface at as
+a standalone request.
 
 ## Common causes
 

--- a/docs/problems/unknown_field.md
+++ b/docs/problems/unknown_field.md
@@ -4,13 +4,20 @@ a field that exists in the schema but under a different
 `asset_type` (or `maintenance_record_type`) is still reported as
 unknown for the type the event addressed.
 
-The response carries the following extension members:
+The problem body carries the following extension members:
 
 - `family` — the entity family the event targeted (`asset` or
   `maintenance_record`).
 - `type_id` — the user-schema type the event addressed.
 - `field` — the unrecognised field key, either a UUID (user
   field) or `col:<column>` (projection column).
+
+On `/events` the rejection arrives as a per-event entry in the
+response's `outcomes` array: `outcome` is `rejected:unknown_field`
+and the standard slots + extras above ride at the top of
+`outcomes[i].problem`. The HTTP status is the batch envelope's `202`;
+`problem.status` carries the `404` this rejection would surface at as
+a standalone request.
 
 ## Common causes
 

--- a/docs/problems/value_type_mismatch.md
+++ b/docs/problems/value_type_mismatch.md
@@ -5,7 +5,7 @@ JSON booleans for `boolean`, ISO 8601 strings for `date` /
 `datetime`. `null` is always accepted (it is the "clear this cell"
 sentinel per the wire format).
 
-The response carries the following extension members:
+The problem body carries the following extension members:
 
 - `field` — the field key (UUID or `col:<column>`) whose value
   failed validation.
@@ -13,6 +13,13 @@ The response carries the following extension members:
   `integer`).
 - `received` — the JSON type observed (`string`, `number`,
   `integer`, `boolean`, `null`, `object`, `array`).
+
+On `/events` the rejection arrives as a per-event entry in the
+response's `outcomes` array: `outcome` is `rejected:value_type_mismatch`
+and the standard slots + extras above ride at the top of
+`outcomes[i].problem`. The HTTP status is the batch envelope's `202`;
+`problem.status` carries the `400` this rejection would surface at as
+a standalone request.
 
 ## Common causes
 

--- a/src/py/novamoc/api/_problem_details.py
+++ b/src/py/novamoc/api/_problem_details.py
@@ -25,7 +25,7 @@ registers them on the `ProblemDetailsPlugin`.
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import msgspec
 from litestar.plugins.problem_details import ProblemDetailsException
@@ -100,6 +100,30 @@ def make_instance() -> str:
     """Return an opaque per-occurrence instance identifier (`urn:uuid:<uuid4>`)."""
 
     return f"urn:uuid:{uuid.uuid4()}"
+
+
+def make_problem_body(exc: DomainError, base_url: str) -> dict[str, Any]:
+    """RFC 9457 problem-details body for ``exc``.
+
+    The dict matches the JSON shape an ``application/problem+json``
+    response would carry: standard slots first (``type``, ``title``,
+    ``status``, ``detail``, ``instance``), then per-error extras as
+    top-level extension members per RFC 9457 §3.2.
+
+    Callers in the events endpoint embed this dict under
+    ``EventOutcome.problem`` so a rejected per-event outcome carries
+    the same diagnostic surface a batch-level error response would.
+    """
+    body: dict[str, Any] = {
+        "type": _type_uri(exc.code, base_url),
+        "title": _TITLES[exc.code],
+        "status": _STATUS_CODES[exc.code],
+        "detail": exc.message,
+        "instance": make_instance(),
+    }
+    if exc.extras:
+        body.update(exc.extras)
+    return body
 
 
 def make_domain_error_converter(

--- a/src/py/novamoc/domain/events/_bundle.py
+++ b/src/py/novamoc/domain/events/_bundle.py
@@ -1,36 +1,69 @@
-"""Per-request aggregator of services + the field-set memo handlers use.
+"""Per-request aggregator for the events handlers.
 
-Lives here rather than in ``_dispatch`` or ``_handlers/__init__`` so both
-can import it without setting up a circular dependency. The bundle is
-built once per request in :class:`EventsController.append` and lives for
-the duration of that handler call — schema cannot change mid-request, so
-the memo has no invalidation surface.
+Holds the services + memo that handlers need and the
+:meth:`append_event` helper that does the savepoint-isolated
+``event_log`` insert. Built once per request in
+:class:`EventsController.append` and lives for the duration of that
+call — schema cannot change mid-request, so the memo has no
+invalidation surface.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Final
 
-from novamoc.domain.events._payloads import EntityFamily
+import msgspec
+from advanced_alchemy.exceptions import IntegrityError as RepositoryIntegrityError
+
+from novamoc.db.models.data import EventOp
+from novamoc.domain.events._payloads import (
+    Deactivated,
+    EntityFamily,
+    EventOutcome,
+)
 
 if TYPE_CHECKING:
     from uuid import UUID
 
     from novamoc.db.models.schema import AssetTypeField, MaintenanceRecordTypeField
     from novamoc.domain.accounts import RequestAuth
-    from novamoc.domain.events._payloads import EventEnvelope
+    from novamoc.domain.events._payloads import EventBody, EventEnvelope
+    from novamoc.domain.events.services import EventLogService
     from novamoc.domain.schema.services import (
         AssetTypeFieldService,
         MaintenanceRecordTypeFieldService,
     )
 
 
+_TABLE_NAMES: Final[dict[EntityFamily, str]] = {
+    EntityFamily.ASSET: "assets",
+    EntityFamily.MAINTENANCE_RECORD: "maintenance_records",
+}
+
+
+def _op_for_body(body: EventBody) -> EventOp:
+    """``deactivated`` events are deletes; everything else is a set."""
+    if isinstance(body, Deactivated):
+        return EventOp.DELETE
+    return EventOp.SET
+
+
+def _value_json_for_body(body: EventBody) -> dict[str, Any] | None:
+    """``Deactivated`` carries no payload; everything else round-trips
+    through msgspec to match the wire shape."""
+    if isinstance(body, Deactivated):
+        return None
+    return msgspec.to_builtins(body)
+
+
 @dataclass(frozen=True, slots=True)
 class EventServiceBundle:
     asset_type_field_service: AssetTypeFieldService
     maintenance_record_type_field_service: MaintenanceRecordTypeFieldService
+    event_log_service: EventLogService
+    schema_version: int
     _fields_cache: dict[
         tuple[EntityFamily, UUID],
         dict[UUID, AssetTypeField | MaintenanceRecordTypeField],
@@ -58,10 +91,44 @@ class EventServiceBundle:
         self._fields_cache[key] = loaded
         return loaded
 
+    async def append_event(self, event: EventEnvelope) -> EventOutcome:
+        """Insert one ``event_log`` row inside a savepoint.
+
+        The savepoint isolates the ``IntegrityError`` path so the outer
+        transaction (committed at response time by the autocommit
+        handler) stays usable for subsequent events in the batch.
+
+        Returns:
+            ``accepted`` for a fresh insert, ``duplicate`` if the
+            ``UNIQUE(tenant_id, hlc)`` constraint was hit.
+        """
+        session = self.event_log_service.repository.session
+        try:
+            async with session.begin_nested():
+                await self.event_log_service.create(
+                    data={
+                        "hlc": event.hlc,
+                        "schema_version": self.schema_version,
+                        "table_name": _TABLE_NAMES[event.family],
+                        "entity_id": str(event.instance_id),
+                        "field_id": None,
+                        "op": _op_for_body(event.body),
+                        "value_json": _value_json_for_body(event.body),
+                    },
+                    auto_commit=False,
+                )
+        except RepositoryIntegrityError:
+            # advanced_alchemy wraps SQLAlchemy IntegrityError into its
+            # own taxonomy (DuplicateKeyError extends this). The
+            # savepoint rolled back, so the outer transaction is still
+            # usable.
+            return EventOutcome(hlc=event.hlc, outcome="duplicate")
+        return EventOutcome(hlc=event.hlc, outcome="accepted")
+
 
 # Lazily-evaluated alias so the names used here can stay under TYPE_CHECKING.
 type Handler = Callable[
-    [EventServiceBundle, "RequestAuth", "EventEnvelope"], Awaitable[None]
+    [EventServiceBundle, "RequestAuth", "EventEnvelope"], Awaitable[EventOutcome]
 ]
 
 

--- a/src/py/novamoc/domain/events/_dispatch.py
+++ b/src/py/novamoc/domain/events/_dispatch.py
@@ -19,7 +19,7 @@ from novamoc.domain.events._payloads import EntityFamily
 if TYPE_CHECKING:
     from novamoc.domain.accounts import RequestAuth
     from novamoc.domain.events._bundle import EventServiceBundle, Handler
-    from novamoc.domain.events._payloads import EventEnvelope
+    from novamoc.domain.events._payloads import EventEnvelope, EventOutcome
 
 
 __all__ = ("dispatch",)
@@ -45,5 +45,5 @@ async def dispatch(
     services: EventServiceBundle,
     auth: RequestAuth,
     event: EventEnvelope,
-) -> None:
-    await _HANDLERS[(event.family, type(event.body))](services, auth, event)
+) -> EventOutcome:
+    return await _HANDLERS[(event.family, type(event.body))](services, auth, event)

--- a/src/py/novamoc/domain/events/_handlers/asset.py
+++ b/src/py/novamoc/domain/events/_handlers/asset.py
@@ -1,20 +1,17 @@
 """Asset-family event handlers.
 
 Each function is one cell of the (family, body_type) dispatch matrix
-(see ``_dispatch.py``). In M1.4 the handlers do field/value validation
-only; persistence and projection writes arrive with M1.5+ in the same
-cells.
+(see ``_dispatch.py``). Created/updated handlers validate the
+``values`` payload against the type's field set before persisting;
+deactivated/activated handlers carry no payload and go straight to
+the append.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from novamoc.domain.events._payloads import (
-    Activated,
-    Deactivated,
-    EntityFamily,
-)
+from novamoc.domain.events._payloads import EntityFamily
 from novamoc.domain.events._validators import validate_values
 
 if TYPE_CHECKING:
@@ -23,37 +20,40 @@ if TYPE_CHECKING:
     from novamoc.domain.events._payloads import (
         Created,
         EventEnvelope,
+        EventOutcome,
         Updated,
     )
 
 
 async def created(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
+) -> EventOutcome:
     body = cast("Created", event.body)
-    _ = auth  # reserved for M1.5+ tenant-scoped writes
+    _ = auth  # reserved for future tenant-scoped writes
     fields_by_id = await services.fields_for(EntityFamily.ASSET, event.type_id)
     validate_values(event=event, values=body.values, fields_by_id=fields_by_id)
+    return await services.append_event(event)
 
 
 async def updated(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
+) -> EventOutcome:
     body = cast("Updated", event.body)
-    _ = auth  # reserved for M1.5+ tenant-scoped writes
+    _ = auth
     fields_by_id = await services.fields_for(EntityFamily.ASSET, event.type_id)
     validate_values(event=event, values=body.values, fields_by_id=fields_by_id)
+    return await services.append_event(event)
 
 
 async def deactivated(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
-    # Row-state event; no field/value payload. M1.5+ adds the deactivate path.
-    _ = (services, auth, event, Deactivated)
+) -> EventOutcome:
+    _ = auth
+    return await services.append_event(event)
 
 
 async def activated(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
-    # Row-state event; no field/value payload. M1.5+ adds the activate path.
-    _ = (services, auth, event, Activated)
+) -> EventOutcome:
+    _ = auth
+    return await services.append_event(event)

--- a/src/py/novamoc/domain/events/_handlers/maintenance_record.py
+++ b/src/py/novamoc/domain/events/_handlers/maintenance_record.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from novamoc.domain.events._payloads import (
-    Activated,
-    Deactivated,
-    EntityFamily,
-)
+from novamoc.domain.events._payloads import EntityFamily
 from novamoc.domain.events._validators import validate_values
 
 if TYPE_CHECKING:
@@ -17,39 +13,44 @@ if TYPE_CHECKING:
     from novamoc.domain.events._payloads import (
         Created,
         EventEnvelope,
+        EventOutcome,
         Updated,
     )
 
 
 async def created(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
+) -> EventOutcome:
     body = cast("Created", event.body)
-    _ = auth  # reserved for M1.5+ tenant-scoped writes
+    _ = auth
     fields_by_id = await services.fields_for(
         EntityFamily.MAINTENANCE_RECORD, event.type_id
     )
     validate_values(event=event, values=body.values, fields_by_id=fields_by_id)
+    return await services.append_event(event)
 
 
 async def updated(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
+) -> EventOutcome:
     body = cast("Updated", event.body)
-    _ = auth  # reserved for M1.5+ tenant-scoped writes
+    _ = auth
     fields_by_id = await services.fields_for(
         EntityFamily.MAINTENANCE_RECORD, event.type_id
     )
     validate_values(event=event, values=body.values, fields_by_id=fields_by_id)
+    return await services.append_event(event)
 
 
 async def deactivated(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
-    _ = (services, auth, event, Deactivated)
+) -> EventOutcome:
+    _ = auth
+    return await services.append_event(event)
 
 
 async def activated(
     services: EventServiceBundle, auth: RequestAuth, event: EventEnvelope
-) -> None:
-    _ = (services, auth, event, Activated)
+) -> EventOutcome:
+    _ = auth
+    return await services.append_event(event)

--- a/src/py/novamoc/domain/events/_payloads.py
+++ b/src/py/novamoc/domain/events/_payloads.py
@@ -131,12 +131,46 @@ class EventEnvelope(msgspec.Struct, forbid_unknown_fields=True):
 
 
 class EventBatch(msgspec.Struct, forbid_unknown_fields=True):
-    """Batch posted to ``POST /events``, applied transactionally.
+    """Batch posted to ``POST /events``.
+
+    Per-event outcomes (see :class:`EventOutcome`) are atomic at the
+    event grain, not the batch grain (M1.5): one rejected or duplicate
+    event does not poison its neighbours. Batch-level failures
+    (``schema_version_stale``, malformed body) still reject the
+    whole submission via the ``application/problem+json`` envelope.
 
     Attributes:
         schema_version: Client's loaded schema state (ADR-008/009).
-        events: Ordered tuple; all succeed or none do.
+        events: Ordered tuple. Order is preserved in the response.
     """
 
     schema_version: int
     events: tuple[EventEnvelope, ...]
+
+
+class EventOutcome(msgspec.Struct, forbid_unknown_fields=True):
+    """Per-event outcome in the ``POST /events`` response.
+
+    ``outcome`` is one of:
+
+    - ``accepted`` — appended to ``event_log``.
+    - ``duplicate`` — a row with the same ``(tenant_id, hlc)`` already
+      exists (idempotent re-delivery, ADR-011).
+    - ``rejected:<code>`` — per-event validation failed; ``<code>`` is
+      the corresponding :class:`ErrorCode` value (``hlc_drift_exceeded``,
+      ``unknown_field``, ``value_type_mismatch``, or
+      ``invalid_payload_shape``).
+    """
+
+    hlc: str
+    outcome: str
+
+
+class EventBatchResponse(msgspec.Struct, forbid_unknown_fields=True):
+    """Response body for ``POST /events``.
+
+    ``outcomes`` is ordered to match the input ``events`` tuple, so a
+    client can correlate by index in addition to by ``hlc``.
+    """
+
+    outcomes: tuple[EventOutcome, ...]

--- a/src/py/novamoc/domain/events/_payloads.py
+++ b/src/py/novamoc/domain/events/_payloads.py
@@ -148,7 +148,7 @@ class EventBatch(msgspec.Struct, forbid_unknown_fields=True):
     events: tuple[EventEnvelope, ...]
 
 
-class EventOutcome(msgspec.Struct, forbid_unknown_fields=True):
+class EventOutcome(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
     """Per-event outcome in the ``POST /events`` response.
 
     ``outcome`` is one of:
@@ -160,10 +160,20 @@ class EventOutcome(msgspec.Struct, forbid_unknown_fields=True):
       the corresponding :class:`ErrorCode` value (``hlc_drift_exceeded``,
       ``unknown_field``, ``value_type_mismatch``, or
       ``invalid_payload_shape``).
+
+    Rejected outcomes also carry ``problem``, a dict shaped like the
+    ``application/problem+json`` body the same error would produce at
+    batch level — standard RFC 9457 slots (``type``, ``title``,
+    ``status``, ``detail``, ``instance``) plus per-code extension
+    members at top level (e.g. ``drift_seconds``, ``field``,
+    ``expected``). The docs page pointed to by ``problem.type``
+    documents the per-code extras. Omitted for ``accepted`` and
+    ``duplicate``.
     """
 
     hlc: str
     outcome: str
+    problem: dict[str, Any] | None = None
 
 
 class EventBatchResponse(msgspec.Struct, forbid_unknown_fields=True):

--- a/src/py/novamoc/domain/events/controllers/_events.py
+++ b/src/py/novamoc/domain/events/controllers/_events.py
@@ -1,61 +1,220 @@
 """HTTP controller for ``/events`` (ADR-013).
 
-The controller enforces three pre-persistence batch gates and then
-delegates each event to its handler:
+The controller runs the request through one batch-level gate and a
+per-event pipeline. Batch-level failures (``schema_version_stale``,
+malformed body) reject the whole submission via
+``application/problem+json``; per-event outcomes are atomic at the
+event grain (M1.5).
 
 1. **Schema-version gate** (batch-level, M1.3 / ADR-008 / ADR-009): the
    batch's ``schema_version`` must equal the tenant's current schema
    version. A mismatch raises ``schema_version_stale``.
-2. **HLC parse + drift bound** (per-event, M1.2 / ADR-006): each event's
-   ``hlc`` is parsed; an HLC whose physical component sits more than
-   ``AppSettings.hlc_drift_limit_seconds`` ahead of server wall time is
-   rejected as ``hlc_drift_exceeded``. Past HLCs are always accepted —
-   drift is one-sided.
-3. **Per-event handler dispatch** (M1.4): each event is routed to the
-   handler matching ``(event.family, type(event.body))``. Today the
-   handlers do field-existence + value-shape validation; M1.5+ layers
-   persistence, projection writes, and business rules into the same
-   cells.
 
-The controller does not import ``_validators`` — that machinery is
-called by the handlers, not by the controller.
+For each event in order:
+
+* HLC parse + drift check (M1.2, ADR-006). Malformed HLCs and HLCs
+  more than ``AppSettings.hlc_drift_limit_seconds`` ahead of the
+  server are reported as ``rejected:invalid_payload_shape`` and
+  ``rejected:hlc_drift_exceeded`` respectively.
+* Handler dispatch (M1.4). The ``(family, body_type)`` handler runs
+  field-existence + value-shape validation; the controller does not
+  import ``_validators`` directly. Domain errors raised by the
+  handler are reported as ``rejected:<code>``.
+* Append to ``event_log`` (M1.5, ADR-011). A row whose
+  ``UNIQUE(tenant_id, hlc)`` collides with an existing row is
+  reported as ``duplicate`` (idempotent re-delivery). Inserts run
+  inside a ``begin_nested()`` savepoint so an ``IntegrityError`` on
+  one event leaves the surrounding transaction usable for the next.
+
+Projection writes (field-value LWW, row state, entity-table updates)
+land in M1.6+. This controller currently only writes to
+``event_log``; the fold runs against that log later.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+import msgspec
+from advanced_alchemy.exceptions import IntegrityError as RepositoryIntegrityError
 from advanced_alchemy.extensions.litestar import providers
 from litestar import Controller, Request, post
 from litestar.datastructures import (
     State,  # noqa: TC002  # runtime DI provider annotation
 )
 from litestar.di import Provide
-from litestar.exceptions import ValidationException
 from litestar.status_codes import HTTP_202_ACCEPTED
 
-from novamoc.domain.events import _payloads
+from novamoc.db.models.data import EventOp
+from novamoc.domain._errors import DomainError, ErrorCode
 from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._dispatch import dispatch
-from novamoc.domain.events._errors import (
-    HLCDriftExceededError,
-    SchemaVersionStaleError,
-)
+from novamoc.domain.events._errors import SchemaVersionStaleError
 from novamoc.domain.events._hlc import HLC, HLCParseError, wall_now_ms
+from novamoc.domain.events._payloads import (
+    Deactivated,
+    EntityFamily,
+    EventBatch,
+    EventBatchResponse,
+    EventOutcome,
+)
+from novamoc.domain.events.services import EventLogService
 from novamoc.domain.schema.services import (
     AssetTypeFieldService,
     MaintenanceRecordTypeFieldService,
     SchemaChangeLogService,
 )
 
+if TYPE_CHECKING:
+    from novamoc.domain.accounts import RequestAuth
+    from novamoc.domain.events._payloads import EventEnvelope
+
+
+# Map each entity family to the projection table_name recorded on the
+# event_log row. The fold (M1.6+) routes on this column.
+_TABLE_NAMES: Final[dict[EntityFamily, str]] = {
+    EntityFamily.ASSET: "assets",
+    EntityFamily.MAINTENANCE_RECORD: "maintenance_records",
+}
+
 
 async def _provide_drift_limit_seconds(state: State) -> float:
     return state.settings.app.hlc_drift_limit_seconds
+
+
+@dataclass(frozen=True, slots=True)
+class AppendDeps:
+    """Aggregated dependencies for :meth:`EventsController.append`.
+
+    Bundles services + tunables into one DI-injectable container so
+    the handler signature stays narrow. Public name (no underscore
+    prefix) because Litestar's signature parser resolves the type at
+    import time when binding the parameter.
+    """
+
+    drift_limit_seconds: float
+    change_log: SchemaChangeLogService
+    asset_field: AssetTypeFieldService
+    record_field: MaintenanceRecordTypeFieldService
+    event_log: EventLogService
+
+
+async def _provide_append_deps(
+    drift_limit_seconds: float,
+    schema_change_log_service: SchemaChangeLogService,
+    asset_type_field_service: AssetTypeFieldService,
+    maintenance_record_type_field_service: MaintenanceRecordTypeFieldService,
+    event_log_service: EventLogService,
+) -> AppendDeps:
+    return AppendDeps(
+        drift_limit_seconds=drift_limit_seconds,
+        change_log=schema_change_log_service,
+        asset_field=asset_type_field_service,
+        record_field=maintenance_record_type_field_service,
+        event_log=event_log_service,
+    )
+
+
+def _op_for_body(body: object) -> EventOp:
+    """``deactivated`` events are deletes; everything else is a set."""
+    if isinstance(body, Deactivated):
+        return EventOp.DELETE
+    return EventOp.SET
+
+
+def _value_json_for_body(body: object) -> dict[str, Any] | None:
+    """Round-trip the body through msgspec so the stored payload
+    matches the wire shape. ``Deactivated`` carries no payload."""
+    if isinstance(body, Deactivated):
+        return None
+    return msgspec.to_builtins(body)
+
+
+class _RejectOutcomeError(Exception):
+    """Sentinel raised by per-event validators to short-circuit the
+    pipeline with a ``rejected:<code>`` outcome."""
+
+    def __init__(self, code: ErrorCode) -> None:
+        super().__init__(code.value)
+        self.code = code
+
+
+async def _validate_event(
+    event: EventEnvelope,
+    *,
+    server_now_ms: int,
+    limit_ms: int,
+    services: EventServiceBundle,
+    auth: RequestAuth,
+) -> None:
+    """Run M1.2 HLC + M1.4 dispatch checks for one event.
+
+    Raises:
+        _RejectOutcomeError: validation failed; the caller maps the
+            attached ``code`` to a ``rejected:<code>`` outcome.
+    """
+    try:
+        parsed = HLC.parse(event.hlc)
+    except HLCParseError as exc:
+        raise _RejectOutcomeError(ErrorCode.INVALID_PAYLOAD_SHAPE) from exc
+
+    drift_ms = parsed.physical_ms - server_now_ms
+    if drift_ms > limit_ms:
+        raise _RejectOutcomeError(ErrorCode.HLC_DRIFT_EXCEEDED)
+
+    try:
+        await dispatch(services, auth, event)
+    except DomainError as exc:
+        raise _RejectOutcomeError(exc.code) from exc
+
+
+async def _append_one(
+    event: EventEnvelope,
+    *,
+    schema_version: int,
+    event_log_service: EventLogService,
+) -> EventOutcome:
+    """Insert one ``event_log`` row inside a savepoint.
+
+    The savepoint isolates the ``IntegrityError`` path so the outer
+    transaction — committed at response time by the autocommit
+    handler — stays usable for subsequent events in the batch.
+
+    Returns:
+        ``accepted`` or ``duplicate`` outcome.
+    """
+    session = event_log_service.repository.session
+    try:
+        async with session.begin_nested():
+            await event_log_service.create(
+                data={
+                    "hlc": event.hlc,
+                    "schema_version": schema_version,
+                    "table_name": _TABLE_NAMES[event.family],
+                    "entity_id": str(event.instance_id),
+                    "field_id": None,
+                    "op": _op_for_body(event.body),
+                    "value_json": _value_json_for_body(event.body),
+                },
+                auto_commit=False,
+            )
+    except RepositoryIntegrityError:
+        # advanced_alchemy wraps SQLAlchemy IntegrityError into its own
+        # taxonomy (DuplicateKeyError extends this). The savepoint
+        # rolled back, so the outer transaction is still usable.
+        return EventOutcome(hlc=event.hlc, outcome="duplicate")
+    return EventOutcome(hlc=event.hlc, outcome="accepted")
 
 
 class EventsController(Controller):
     path = "/events"
     tags = ("events",)
     dependencies = (
-        {"drift_limit_seconds": Provide(_provide_drift_limit_seconds)}
+        {
+            "drift_limit_seconds": Provide(_provide_drift_limit_seconds),
+            "deps": Provide(_provide_append_deps),
+        }
         | providers.create_service_dependencies(
             SchemaChangeLogService, "schema_change_log_service"
         )
@@ -65,22 +224,20 @@ class EventsController(Controller):
         | providers.create_service_dependencies(
             MaintenanceRecordTypeFieldService, "maintenance_record_type_field_service"
         )
+        | providers.create_service_dependencies(EventLogService, "event_log_service")
     )
 
     @post("/", status_code=HTTP_202_ACCEPTED)
-    async def append(  # noqa: PLR0913  # one parameter per DI'd service; Litestar pattern
+    async def append(
         self,
-        data: _payloads.EventBatch,
+        data: EventBatch,
         request: Request,
-        drift_limit_seconds: float,
-        schema_change_log_service: SchemaChangeLogService,
-        asset_type_field_service: AssetTypeFieldService,
-        maintenance_record_type_field_service: MaintenanceRecordTypeFieldService,
-    ) -> None:
+        deps: AppendDeps,
+    ) -> EventBatchResponse:
         # 1. Batch-level schema-version gate. Runs before HLC parsing so a
         # stale-schema client sees the actionable error (re-fetch /schema)
         # instead of a downstream HLC complaint.
-        current_version = await schema_change_log_service.current_version()
+        current_version = await deps.change_log.current_version()
         if data.schema_version != current_version:
             raise SchemaVersionStaleError(
                 expected=current_version,
@@ -91,26 +248,34 @@ class EventsController(Controller):
         # edge of the drift budget cannot get re-checked against a later
         # server time mid-iteration.
         server_now_ms = wall_now_ms()
-        limit_ms = int(drift_limit_seconds * 1000)
+        limit_ms = int(deps.drift_limit_seconds * 1000)
 
         services = EventServiceBundle(
-            asset_type_field_service=asset_type_field_service,
-            maintenance_record_type_field_service=maintenance_record_type_field_service,
+            asset_type_field_service=deps.asset_field,
+            maintenance_record_type_field_service=deps.record_field,
         )
 
+        outcomes: list[EventOutcome] = []
         for event in data.events:
-            # 2. Per-event envelope check (HLC parse + drift bound).
             try:
-                parsed = HLC.parse(event.hlc)
-            except HLCParseError as exc:
-                raise ValidationException(detail=str(exc)) from exc
-            drift_ms = parsed.physical_ms - server_now_ms
-            if drift_ms > limit_ms:
-                raise HLCDriftExceededError(
-                    hlc=event.hlc,
-                    drift_seconds=drift_ms / 1000,
-                    limit_seconds=drift_limit_seconds,
+                await _validate_event(
+                    event,
+                    server_now_ms=server_now_ms,
+                    limit_ms=limit_ms,
+                    services=services,
+                    auth=request.auth,
                 )
+            except _RejectOutcomeError as rej:
+                outcomes.append(
+                    EventOutcome(hlc=event.hlc, outcome=f"rejected:{rej.code.value}")
+                )
+                continue
 
-            # 3. Dispatch to the (family, body_type) handler.
-            await dispatch(services, request.auth, event)
+            outcome = await _append_one(
+                event,
+                schema_version=data.schema_version,
+                event_log_service=deps.event_log,
+            )
+            outcomes.append(outcome)
+
+        return EventBatchResponse(outcomes=tuple(outcomes))

--- a/src/py/novamoc/domain/events/controllers/_events.py
+++ b/src/py/novamoc/domain/events/controllers/_events.py
@@ -7,21 +7,26 @@ is atomic at the event grain (M1.5).
 The controller is thin: one batch-level gate, a per-event HLC check,
 and a dispatch call. The (family, body_type) handler — not the
 controller — runs field/value validation *and* the ``event_log``
-append, returning the per-event :class:`EventOutcome`. The controller
-maps any ``DomainError`` raised by the handler to a
-``rejected:<code>`` outcome and aggregates the response.
+append, returning the per-event :class:`EventOutcome`. Any
+``DomainError`` raised on the per-event path (HLC parse, HLC drift, or
+the handler itself) is converted to a ``rejected:<code>`` outcome
+carrying the same problem-details body the exception would render at
+batch level — extras (``drift_seconds``, ``field``, ...) ride at the
+top of ``EventOutcome.problem`` per RFC 9457 / ADR-016.
 
 Batch-level: ``schema_version`` must equal the tenant's current schema
 version (M1.3 / ADR-008 / ADR-009).
 
 Per event, in order:
 
-* HLC parse + drift check (M1.2 / ADR-006) → ``rejected:invalid_payload_shape``
-  or ``rejected:hlc_drift_exceeded``.
+* HLC parse + drift check (M1.2 / ADR-006). The bad-shape and
+  drift-exceeded paths raise ``PayloadShapeError`` /
+  ``HLCDriftExceededError`` so the same problem-details translation
+  runs as for handler errors.
 * Handler dispatch (M1.4 + M1.5). The handler validates, appends to
-  ``event_log`` in a savepoint, and returns ``accepted`` / ``duplicate``.
-  A ``DomainError`` raised before the append becomes
-  ``rejected:<code>``.
+  ``event_log`` in a savepoint, and returns ``accepted`` /
+  ``duplicate``. A ``DomainError`` raised before the append becomes a
+  rejected outcome.
 """
 
 from __future__ import annotations
@@ -37,10 +42,14 @@ from litestar.datastructures import (
 from litestar.di import Provide
 from litestar.status_codes import HTTP_202_ACCEPTED
 
-from novamoc.domain._errors import DomainError, ErrorCode
+from novamoc.api._problem_details import make_problem_body
+from novamoc.domain._errors import DomainError, ErrorCode, PayloadShapeError
 from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._dispatch import dispatch
-from novamoc.domain.events._errors import SchemaVersionStaleError
+from novamoc.domain.events._errors import (
+    HLCDriftExceededError,
+    SchemaVersionStaleError,
+)
 from novamoc.domain.events._hlc import HLC, HLCParseError, wall_now_ms
 from novamoc.domain.events._payloads import (
     EventBatch,
@@ -62,24 +71,30 @@ async def _provide_drift_limit_seconds(state: State) -> float:
     return state.settings.app.hlc_drift_limit_seconds
 
 
+async def _provide_docs_base_url(state: State) -> str:
+    return state.settings.app.docs_base_url
+
+
 @dataclass(frozen=True, slots=True)
 class AppendDeps:
     """DI-injectable bundle so :meth:`EventsController.append` takes one
-    parameter instead of five.
+    parameter instead of six.
 
     Public name (no underscore prefix) because Litestar's signature
     parser resolves the type at import time when binding the parameter.
     """
 
     drift_limit_seconds: float
+    docs_base_url: str
     change_log: SchemaChangeLogService
     asset_field: AssetTypeFieldService
     record_field: MaintenanceRecordTypeFieldService
     event_log: EventLogService
 
 
-async def _provide_append_deps(
+async def _provide_append_deps(  # noqa: PLR0913  # one parameter per DI'd dep; Litestar pattern
     drift_limit_seconds: float,
+    docs_base_url: str,
     schema_change_log_service: SchemaChangeLogService,
     asset_type_field_service: AssetTypeFieldService,
     maintenance_record_type_field_service: MaintenanceRecordTypeFieldService,
@@ -87,6 +102,7 @@ async def _provide_append_deps(
 ) -> AppendDeps:
     return AppendDeps(
         drift_limit_seconds=drift_limit_seconds,
+        docs_base_url=docs_base_url,
         change_log=schema_change_log_service,
         asset_field=asset_type_field_service,
         record_field=maintenance_record_type_field_service,
@@ -94,31 +110,70 @@ async def _provide_append_deps(
     )
 
 
-def _rejected(event: EventEnvelope, code: ErrorCode) -> EventOutcome:
-    return EventOutcome(hlc=event.hlc, outcome=f"rejected:{code.value}")
-
-
-async def _process_event(
-    event: EventEnvelope,
-    *,
-    server_now_ms: int,
-    limit_ms: int,
-    services: EventServiceBundle,
-    request: Request,
+def _rejected(
+    event: EventEnvelope, exc: DomainError, docs_base_url: str
 ) -> EventOutcome:
+    """Build a rejected ``EventOutcome`` carrying ``exc``'s problem body.
+
+    The problem dict matches the ``application/problem+json`` shape the
+    same exception would render at batch level — clients can read
+    extras (``drift_seconds``, ``field``, ...) the same way for both
+    paths.
+    """
+    return EventOutcome(
+        hlc=event.hlc,
+        outcome=f"rejected:{exc.code.value}",
+        problem=make_problem_body(exc, docs_base_url),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _BatchContext:
+    """Constants shared by every event in one batch.
+
+    ``server_now_ms`` is read once at the top of the controller so an
+    event at the edge of the drift budget cannot get re-checked against
+    a later server time mid-iteration.
+    """
+
+    server_now_ms: int
+    drift_limit_seconds: float
+    services: EventServiceBundle
+    request: Request
+    docs_base_url: str
+
+
+async def _process_event(event: EventEnvelope, ctx: _BatchContext) -> EventOutcome:
     """HLC check then dispatch; map any ``DomainError`` to a rejected outcome."""
     try:
         parsed = HLC.parse(event.hlc)
-    except HLCParseError:
-        return _rejected(event, ErrorCode.INVALID_PAYLOAD_SHAPE)
+    except HLCParseError as exc:
+        return _rejected(
+            event,
+            PayloadShapeError(
+                code=ErrorCode.INVALID_PAYLOAD_SHAPE,
+                message=str(exc),
+                hlc=event.hlc,
+            ),
+            ctx.docs_base_url,
+        )
 
-    if parsed.physical_ms - server_now_ms > limit_ms:
-        return _rejected(event, ErrorCode.HLC_DRIFT_EXCEEDED)
+    drift_seconds = (parsed.physical_ms - ctx.server_now_ms) / 1000
+    if drift_seconds > ctx.drift_limit_seconds:
+        return _rejected(
+            event,
+            HLCDriftExceededError(
+                hlc=event.hlc,
+                drift_seconds=drift_seconds,
+                limit_seconds=ctx.drift_limit_seconds,
+            ),
+            ctx.docs_base_url,
+        )
 
     try:
-        return await dispatch(services, request.auth, event)
+        return await dispatch(ctx.services, ctx.request.auth, event)
     except DomainError as exc:
-        return _rejected(event, exc.code)
+        return _rejected(event, exc, ctx.docs_base_url)
 
 
 class EventsController(Controller):
@@ -127,6 +182,7 @@ class EventsController(Controller):
     dependencies = (
         {
             "drift_limit_seconds": Provide(_provide_drift_limit_seconds),
+            "docs_base_url": Provide(_provide_docs_base_url),
             "deps": Provide(_provide_append_deps),
         }
         | providers.create_service_dependencies(
@@ -158,28 +214,18 @@ class EventsController(Controller):
                 received=data.schema_version,
             )
 
-        # One server-now read covers the whole batch so an event at the
-        # edge of the drift budget cannot get re-checked against a later
-        # server time mid-iteration.
-        server_now_ms = wall_now_ms()
-        limit_ms = int(deps.drift_limit_seconds * 1000)
-
-        services = EventServiceBundle(
-            asset_type_field_service=deps.asset_field,
-            maintenance_record_type_field_service=deps.record_field,
-            event_log_service=deps.event_log,
-            schema_version=data.schema_version,
+        ctx = _BatchContext(
+            server_now_ms=wall_now_ms(),
+            drift_limit_seconds=deps.drift_limit_seconds,
+            services=EventServiceBundle(
+                asset_type_field_service=deps.asset_field,
+                maintenance_record_type_field_service=deps.record_field,
+                event_log_service=deps.event_log,
+                schema_version=data.schema_version,
+            ),
+            request=request,
+            docs_base_url=deps.docs_base_url,
         )
 
-        outcomes: list[EventOutcome] = []
-        for event in data.events:
-            outcome = await _process_event(
-                event,
-                server_now_ms=server_now_ms,
-                limit_ms=limit_ms,
-                services=services,
-                request=request,
-            )
-            outcomes.append(outcome)
-
+        outcomes = [await _process_event(event, ctx) for event in data.events]
         return EventBatchResponse(outcomes=tuple(outcomes))

--- a/src/py/novamoc/domain/events/controllers/_events.py
+++ b/src/py/novamoc/domain/events/controllers/_events.py
@@ -1,34 +1,23 @@
 """HTTP controller for ``/events`` (ADR-013).
 
-The controller runs the request through one batch-level gate and a
-per-event pipeline. Batch-level failures (``schema_version_stale``,
-malformed body) reject the whole submission via
-``application/problem+json``; per-event outcomes are atomic at the
-event grain (M1.5).
+Batch-level failures (``schema_version_stale``, malformed body) reject
+the whole submission via ``application/problem+json``; per-event work
+is atomic at the event grain (M1.5).
 
-1. **Schema-version gate** (batch-level, M1.3 / ADR-008 / ADR-009): the
-   batch's ``schema_version`` must equal the tenant's current schema
-   version. A mismatch raises ``schema_version_stale``.
+Batch-level: ``schema_version`` must equal the tenant's current schema
+version (M1.3 / ADR-008 / ADR-009).
 
-For each event in order:
+Per event, in order:
 
-* HLC parse + drift check (M1.2, ADR-006). Malformed HLCs and HLCs
-  more than ``AppSettings.hlc_drift_limit_seconds`` ahead of the
-  server are reported as ``rejected:invalid_payload_shape`` and
-  ``rejected:hlc_drift_exceeded`` respectively.
-* Handler dispatch (M1.4). The ``(family, body_type)`` handler runs
-  field-existence + value-shape validation; the controller does not
-  import ``_validators`` directly. Domain errors raised by the
-  handler are reported as ``rejected:<code>``.
-* Append to ``event_log`` (M1.5, ADR-011). A row whose
-  ``UNIQUE(tenant_id, hlc)`` collides with an existing row is
-  reported as ``duplicate`` (idempotent re-delivery). Inserts run
-  inside a ``begin_nested()`` savepoint so an ``IntegrityError`` on
-  one event leaves the surrounding transaction usable for the next.
-
-Projection writes (field-value LWW, row state, entity-table updates)
-land in M1.6+. This controller currently only writes to
-``event_log``; the fold runs against that log later.
+* HLC parse + drift check (M1.2 / ADR-006) → ``rejected:invalid_payload_shape``
+  or ``rejected:hlc_drift_exceeded``.
+* Handler dispatch (M1.4). ``DomainError`` from the
+  ``(family, body_type)`` handler becomes ``rejected:<code>``; the
+  controller does not import ``_validators``.
+* Append to ``event_log`` (M1.5 / ADR-011). A ``UNIQUE(tenant_id, hlc)``
+  collision lands as ``duplicate``. Each insert runs inside a
+  ``begin_nested()`` savepoint so one ``IntegrityError`` does not
+  poison the rest of the batch.
 """
 
 from __future__ import annotations
@@ -85,12 +74,11 @@ async def _provide_drift_limit_seconds(state: State) -> float:
 
 @dataclass(frozen=True, slots=True)
 class AppendDeps:
-    """Aggregated dependencies for :meth:`EventsController.append`.
+    """DI-injectable bundle so :meth:`EventsController.append` takes one
+    parameter instead of five.
 
-    Bundles services + tunables into one DI-injectable container so
-    the handler signature stays narrow. Public name (no underscore
-    prefix) because Litestar's signature parser resolves the type at
-    import time when binding the parameter.
+    Public name (no underscore prefix) because Litestar's signature
+    parser resolves the type at import time when binding the parameter.
     """
 
     drift_limit_seconds: float
@@ -124,16 +112,16 @@ def _op_for_body(body: object) -> EventOp:
 
 
 def _value_json_for_body(body: object) -> dict[str, Any] | None:
-    """Round-trip the body through msgspec so the stored payload
-    matches the wire shape. ``Deactivated`` carries no payload."""
+    """``Deactivated`` carries no payload; everything else round-trips
+    through msgspec to match the wire shape."""
     if isinstance(body, Deactivated):
         return None
     return msgspec.to_builtins(body)
 
 
 class _RejectOutcomeError(Exception):
-    """Sentinel raised by per-event validators to short-circuit the
-    pipeline with a ``rejected:<code>`` outcome."""
+    """Sentinel for per-event validators to short-circuit with a
+    ``rejected:<code>`` outcome."""
 
     def __init__(self, code: ErrorCode) -> None:
         super().__init__(code.value)
@@ -151,8 +139,8 @@ async def _validate_event(
     """Run M1.2 HLC + M1.4 dispatch checks for one event.
 
     Raises:
-        _RejectOutcomeError: validation failed; the caller maps the
-            attached ``code`` to a ``rejected:<code>`` outcome.
+        _RejectOutcomeError: validation failed; ``code`` maps to the
+            ``rejected:<code>`` outcome.
     """
     try:
         parsed = HLC.parse(event.hlc)
@@ -178,11 +166,12 @@ async def _append_one(
     """Insert one ``event_log`` row inside a savepoint.
 
     The savepoint isolates the ``IntegrityError`` path so the outer
-    transaction — committed at response time by the autocommit
-    handler — stays usable for subsequent events in the batch.
+    transaction (committed at response time by the autocommit handler)
+    stays usable for subsequent events in the batch.
 
     Returns:
-        ``accepted`` or ``duplicate`` outcome.
+        ``accepted`` for a fresh insert, ``duplicate`` if the
+        ``UNIQUE(tenant_id, hlc)`` constraint was hit.
     """
     session = event_log_service.repository.session
     try:

--- a/src/py/novamoc/domain/events/controllers/_events.py
+++ b/src/py/novamoc/domain/events/controllers/_events.py
@@ -4,6 +4,13 @@ Batch-level failures (``schema_version_stale``, malformed body) reject
 the whole submission via ``application/problem+json``; per-event work
 is atomic at the event grain (M1.5).
 
+The controller is thin: one batch-level gate, a per-event HLC check,
+and a dispatch call. The (family, body_type) handler — not the
+controller — runs field/value validation *and* the ``event_log``
+append, returning the per-event :class:`EventOutcome`. The controller
+maps any ``DomainError`` raised by the handler to a
+``rejected:<code>`` outcome and aggregates the response.
+
 Batch-level: ``schema_version`` must equal the tenant's current schema
 version (M1.3 / ADR-008 / ADR-009).
 
@@ -11,22 +18,17 @@ Per event, in order:
 
 * HLC parse + drift check (M1.2 / ADR-006) → ``rejected:invalid_payload_shape``
   or ``rejected:hlc_drift_exceeded``.
-* Handler dispatch (M1.4). ``DomainError`` from the
-  ``(family, body_type)`` handler becomes ``rejected:<code>``; the
-  controller does not import ``_validators``.
-* Append to ``event_log`` (M1.5 / ADR-011). A ``UNIQUE(tenant_id, hlc)``
-  collision lands as ``duplicate``. Each insert runs inside a
-  ``begin_nested()`` savepoint so one ``IntegrityError`` does not
-  poison the rest of the batch.
+* Handler dispatch (M1.4 + M1.5). The handler validates, appends to
+  ``event_log`` in a savepoint, and returns ``accepted`` / ``duplicate``.
+  A ``DomainError`` raised before the append becomes
+  ``rejected:<code>``.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING
 
-import msgspec
-from advanced_alchemy.exceptions import IntegrityError as RepositoryIntegrityError
 from advanced_alchemy.extensions.litestar import providers
 from litestar import Controller, Request, post
 from litestar.datastructures import (
@@ -35,15 +37,12 @@ from litestar.datastructures import (
 from litestar.di import Provide
 from litestar.status_codes import HTTP_202_ACCEPTED
 
-from novamoc.db.models.data import EventOp
 from novamoc.domain._errors import DomainError, ErrorCode
 from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._dispatch import dispatch
 from novamoc.domain.events._errors import SchemaVersionStaleError
 from novamoc.domain.events._hlc import HLC, HLCParseError, wall_now_ms
 from novamoc.domain.events._payloads import (
-    Deactivated,
-    EntityFamily,
     EventBatch,
     EventBatchResponse,
     EventOutcome,
@@ -56,16 +55,7 @@ from novamoc.domain.schema.services import (
 )
 
 if TYPE_CHECKING:
-    from novamoc.domain.accounts import RequestAuth
     from novamoc.domain.events._payloads import EventEnvelope
-
-
-# Map each entity family to the projection table_name recorded on the
-# event_log row. The fold (M1.6+) routes on this column.
-_TABLE_NAMES: Final[dict[EntityFamily, str]] = {
-    EntityFamily.ASSET: "assets",
-    EntityFamily.MAINTENANCE_RECORD: "maintenance_records",
-}
 
 
 async def _provide_drift_limit_seconds(state: State) -> float:
@@ -104,96 +94,31 @@ async def _provide_append_deps(
     )
 
 
-def _op_for_body(body: object) -> EventOp:
-    """``deactivated`` events are deletes; everything else is a set."""
-    if isinstance(body, Deactivated):
-        return EventOp.DELETE
-    return EventOp.SET
+def _rejected(event: EventEnvelope, code: ErrorCode) -> EventOutcome:
+    return EventOutcome(hlc=event.hlc, outcome=f"rejected:{code.value}")
 
 
-def _value_json_for_body(body: object) -> dict[str, Any] | None:
-    """``Deactivated`` carries no payload; everything else round-trips
-    through msgspec to match the wire shape."""
-    if isinstance(body, Deactivated):
-        return None
-    return msgspec.to_builtins(body)
-
-
-class _RejectOutcomeError(Exception):
-    """Sentinel for per-event validators to short-circuit with a
-    ``rejected:<code>`` outcome."""
-
-    def __init__(self, code: ErrorCode) -> None:
-        super().__init__(code.value)
-        self.code = code
-
-
-async def _validate_event(
+async def _process_event(
     event: EventEnvelope,
     *,
     server_now_ms: int,
     limit_ms: int,
     services: EventServiceBundle,
-    auth: RequestAuth,
-) -> None:
-    """Run M1.2 HLC + M1.4 dispatch checks for one event.
-
-    Raises:
-        _RejectOutcomeError: validation failed; ``code`` maps to the
-            ``rejected:<code>`` outcome.
-    """
+    request: Request,
+) -> EventOutcome:
+    """HLC check then dispatch; map any ``DomainError`` to a rejected outcome."""
     try:
         parsed = HLC.parse(event.hlc)
-    except HLCParseError as exc:
-        raise _RejectOutcomeError(ErrorCode.INVALID_PAYLOAD_SHAPE) from exc
+    except HLCParseError:
+        return _rejected(event, ErrorCode.INVALID_PAYLOAD_SHAPE)
 
-    drift_ms = parsed.physical_ms - server_now_ms
-    if drift_ms > limit_ms:
-        raise _RejectOutcomeError(ErrorCode.HLC_DRIFT_EXCEEDED)
+    if parsed.physical_ms - server_now_ms > limit_ms:
+        return _rejected(event, ErrorCode.HLC_DRIFT_EXCEEDED)
 
     try:
-        await dispatch(services, auth, event)
+        return await dispatch(services, request.auth, event)
     except DomainError as exc:
-        raise _RejectOutcomeError(exc.code) from exc
-
-
-async def _append_one(
-    event: EventEnvelope,
-    *,
-    schema_version: int,
-    event_log_service: EventLogService,
-) -> EventOutcome:
-    """Insert one ``event_log`` row inside a savepoint.
-
-    The savepoint isolates the ``IntegrityError`` path so the outer
-    transaction (committed at response time by the autocommit handler)
-    stays usable for subsequent events in the batch.
-
-    Returns:
-        ``accepted`` for a fresh insert, ``duplicate`` if the
-        ``UNIQUE(tenant_id, hlc)`` constraint was hit.
-    """
-    session = event_log_service.repository.session
-    try:
-        async with session.begin_nested():
-            await event_log_service.create(
-                data={
-                    "hlc": event.hlc,
-                    "schema_version": schema_version,
-                    "table_name": _TABLE_NAMES[event.family],
-                    "entity_id": str(event.instance_id),
-                    "field_id": None,
-                    "op": _op_for_body(event.body),
-                    "value_json": _value_json_for_body(event.body),
-                },
-                auto_commit=False,
-            )
-    except RepositoryIntegrityError:
-        # advanced_alchemy wraps SQLAlchemy IntegrityError into its own
-        # taxonomy (DuplicateKeyError extends this). The savepoint
-        # rolled back, so the outer transaction is still usable.
-        return EventOutcome(hlc=event.hlc, outcome="duplicate")
-    return EventOutcome(hlc=event.hlc, outcome="accepted")
+        return _rejected(event, exc.code)
 
 
 class EventsController(Controller):
@@ -223,9 +148,9 @@ class EventsController(Controller):
         request: Request,
         deps: AppendDeps,
     ) -> EventBatchResponse:
-        # 1. Batch-level schema-version gate. Runs before HLC parsing so a
-        # stale-schema client sees the actionable error (re-fetch /schema)
-        # instead of a downstream HLC complaint.
+        # Batch-level schema-version gate. Runs before HLC parsing so a
+        # stale-schema client sees the actionable error (re-fetch
+        # /schema) instead of a downstream HLC complaint.
         current_version = await deps.change_log.current_version()
         if data.schema_version != current_version:
             raise SchemaVersionStaleError(
@@ -242,28 +167,18 @@ class EventsController(Controller):
         services = EventServiceBundle(
             asset_type_field_service=deps.asset_field,
             maintenance_record_type_field_service=deps.record_field,
+            event_log_service=deps.event_log,
+            schema_version=data.schema_version,
         )
 
         outcomes: list[EventOutcome] = []
         for event in data.events:
-            try:
-                await _validate_event(
-                    event,
-                    server_now_ms=server_now_ms,
-                    limit_ms=limit_ms,
-                    services=services,
-                    auth=request.auth,
-                )
-            except _RejectOutcomeError as rej:
-                outcomes.append(
-                    EventOutcome(hlc=event.hlc, outcome=f"rejected:{rej.code.value}")
-                )
-                continue
-
-            outcome = await _append_one(
+            outcome = await _process_event(
                 event,
-                schema_version=data.schema_version,
-                event_log_service=deps.event_log,
+                server_now_ms=server_now_ms,
+                limit_ms=limit_ms,
+                services=services,
+                request=request,
             )
             outcomes.append(outcome)
 

--- a/src/py/novamoc/domain/events/services.py
+++ b/src/py/novamoc/domain/events/services.py
@@ -1,0 +1,22 @@
+"""Service wrappers for the events domain.
+
+:class:`EventLogService` provides an advanced-alchemy repository over the
+append-only ``event_log`` table (ADR-011). Same pattern as the schema
+services; tenant scoping is supplied by the listener layer.
+"""
+
+from __future__ import annotations
+
+from advanced_alchemy.extensions.litestar import repository, service
+
+from novamoc.db.models.data import EventLog
+
+
+class EventLogService(service.SQLAlchemyAsyncRepositoryService[EventLog]):
+    class Repo(repository.SQLAlchemyAsyncRepository[EventLog]):
+        model_type = EventLog
+
+    repository_type = Repo
+
+
+__all__ = ("EventLogService",)

--- a/tests/events/test_bundle.py
+++ b/tests/events/test_bundle.py
@@ -8,6 +8,7 @@ import pytest
 
 from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._payloads import EntityFamily
+from novamoc.domain.events.services import EventLogService
 from novamoc.domain.schema.services import (
     AssetTypeFieldService,
     MaintenanceRecordTypeFieldService,
@@ -40,6 +41,8 @@ def event_services(session: AsyncSession) -> EventServiceBundle:
         maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
             session=session
         ),
+        event_log_service=EventLogService(session=session),
+        schema_version=0,
     )
 
 

--- a/tests/events/test_dispatch.py
+++ b/tests/events/test_dispatch.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from novamoc.domain.events import _dispatch as dispatch_mod
 from novamoc.domain.events import _payloads
-from novamoc.domain.events._payloads import EntityFamily
+from novamoc.domain.events._payloads import EntityFamily, EventOutcome
 
 if TYPE_CHECKING:
     import pytest
@@ -18,8 +18,9 @@ async def test_dispatch_routes_created_to_asset_created(
 ) -> None:
     called: list[str] = []
 
-    async def _fake(*_args: Any, **_kwargs: Any) -> None:
+    async def _fake(*_args: Any, **_kwargs: Any) -> EventOutcome:
         called.append("asset.created")
+        return EventOutcome(hlc="0000000000000001-00000-client-a", outcome="accepted")
 
     monkeypatch.setitem(
         dispatch_mod._HANDLERS,
@@ -34,5 +35,6 @@ async def test_dispatch_routes_created_to_asset_created(
         instance_id=uuid4(),
         body=_payloads.Created(values={}),
     )
-    await dispatch_mod.dispatch(services=None, auth=None, event=event)  # ty: ignore[invalid-argument-type]
+    outcome = await dispatch_mod.dispatch(services=None, auth=None, event=event)  # ty: ignore[invalid-argument-type]
     assert called == ["asset.created"]
+    assert outcome.outcome == "accepted"

--- a/tests/events/test_endpoint_drift.py
+++ b/tests/events/test_endpoint_drift.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for HLC drift validation on ``POST /events``."""
+"""End-to-end tests for HLC drift on ``POST /events`` (M1.2 + M1.5)."""
 
 from __future__ import annotations
 
@@ -34,10 +34,6 @@ def _event(hlc: str) -> dict[str, object]:
 
 @pytest.fixture
 def settings() -> Settings:
-    # Tight drift budget so the rejection path is reachable with a
-    # plausible HLC. The default 60s would require an event > 1 min
-    # ahead, which works at runtime but is fragile in test wall-clock
-    # terms.
     return Settings(
         db=DatabaseSettings(
             url="sqlite+aiosqlite:///:memory:",
@@ -56,43 +52,45 @@ async def test_past_hlc_is_accepted(client: AsyncTestClient) -> None:
         json={"schema_version": 0, "events": [_event(_PAST_HLC)]},
     )
     assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["outcomes"] == [{"hlc": _PAST_HLC, "outcome": "accepted"}]
 
 
-async def test_far_future_hlc_is_rejected_as_drift_exceeded(
+async def test_far_future_hlc_yields_rejected_outcome(
     client: AsyncTestClient,
 ) -> None:
+    # Per M1.5 drift is now a per-event reject, not a batch 4xx; the
+    # batch HTTP envelope still returns 202.
     resp = await client.post(
         "/events",
         json={"schema_version": 0, "events": [_event(_FAR_FUTURE_HLC)]},
     )
-    assert resp.status_code == 400, resp.text
+    assert resp.status_code == 202, resp.text
     body = resp.json()
-    assert body["type"] == "http://test/problems/hlc_drift_exceeded.html"
-    assert body["title"] == "HLC drift exceeded"
-    assert body["status"] == 400
-    assert body["hlc"] == _FAR_FUTURE_HLC
-    assert body["limit_seconds"] == 5.0
-    assert body["drift_seconds"] > 5.0
+    assert body["outcomes"] == [
+        {"hlc": _FAR_FUTURE_HLC, "outcome": "rejected:hlc_drift_exceeded"}
+    ]
 
 
-async def test_malformed_hlc_is_rejected_as_invalid_payload_shape(
+async def test_malformed_hlc_yields_rejected_invalid_payload_shape(
     client: AsyncTestClient,
 ) -> None:
     resp = await client.post(
         "/events",
         json={"schema_version": 0, "events": [_event("not-an-hlc")]},
     )
-    assert resp.status_code == 400, resp.text
+    assert resp.status_code == 202, resp.text
     body = resp.json()
-    assert body["type"] == "http://test/problems/invalid_payload_shape.html"
+    assert body["outcomes"] == [
+        {"hlc": "not-an-hlc", "outcome": "rejected:invalid_payload_shape"}
+    ]
 
 
-async def test_first_bad_event_rejects_whole_batch(
+async def test_mixed_batch_records_each_event_independently(
     client: AsyncTestClient,
 ) -> None:
-    # Atomicity contract: even though persistence lands in later
-    # milestones, the rejection path refuses a batch containing a bad
-    # event rather than partial-accepting it.
+    # A drift-exceeded event does NOT poison its neighbours (M1.5
+    # acceptance criteria): accepted events still apply.
     resp = await client.post(
         "/events",
         json={
@@ -100,9 +98,14 @@ async def test_first_bad_event_rejects_whole_batch(
             "events": [
                 _event(_PAST_HLC),
                 _event(_FAR_FUTURE_HLC),
-                _event(_PAST_HLC),
+                _event("0000000000000002-00000-client-a"),
             ],
         },
     )
-    assert resp.status_code == 400, resp.text
-    assert resp.json()["hlc"] == _FAR_FUTURE_HLC
+    assert resp.status_code == 202, resp.text
+    outcomes = resp.json()["outcomes"]
+    assert [o["outcome"] for o in outcomes] == [
+        "accepted",
+        "rejected:hlc_drift_exceeded",
+        "accepted",
+    ]

--- a/tests/events/test_endpoint_drift.py
+++ b/tests/events/test_endpoint_drift.py
@@ -67,9 +67,18 @@ async def test_far_future_hlc_yields_rejected_outcome(
     )
     assert resp.status_code == 202, resp.text
     body = resp.json()
-    assert body["outcomes"] == [
-        {"hlc": _FAR_FUTURE_HLC, "outcome": "rejected:hlc_drift_exceeded"}
-    ]
+    assert len(body["outcomes"]) == 1
+    outcome = body["outcomes"][0]
+    assert outcome["hlc"] == _FAR_FUTURE_HLC
+    assert outcome["outcome"] == "rejected:hlc_drift_exceeded"
+    problem = outcome["problem"]
+    assert problem["type"] == "http://test/problems/hlc_drift_exceeded.html"
+    assert problem["title"] == "HLC drift exceeded"
+    assert problem["status"] == 400
+    # Top-level extension members per RFC 9457 §3.2 / ADR-016.
+    assert problem["hlc"] == _FAR_FUTURE_HLC
+    assert problem["limit_seconds"] == 5.0
+    assert problem["drift_seconds"] > 5.0
 
 
 async def test_malformed_hlc_yields_rejected_invalid_payload_shape(
@@ -81,9 +90,15 @@ async def test_malformed_hlc_yields_rejected_invalid_payload_shape(
     )
     assert resp.status_code == 202, resp.text
     body = resp.json()
-    assert body["outcomes"] == [
-        {"hlc": "not-an-hlc", "outcome": "rejected:invalid_payload_shape"}
-    ]
+    assert len(body["outcomes"]) == 1
+    outcome = body["outcomes"][0]
+    assert outcome["hlc"] == "not-an-hlc"
+    assert outcome["outcome"] == "rejected:invalid_payload_shape"
+    problem = outcome["problem"]
+    assert problem["type"] == "http://test/problems/invalid_payload_shape.html"
+    assert problem["title"] == "Invalid payload shape"
+    assert problem["status"] == 400
+    assert problem["hlc"] == "not-an-hlc"
 
 
 async def test_mixed_batch_records_each_event_independently(

--- a/tests/events/test_endpoint_idempotency.py
+++ b/tests/events/test_endpoint_idempotency.py
@@ -1,0 +1,97 @@
+"""Idempotency tests for ``POST /events`` (M1.5, ADR-011).
+
+A retried batch with the same HLCs returns ``duplicate`` outcomes
+instead of double-applying. The ``UNIQUE(tenant_id, hlc)`` constraint
+on ``event_log`` is the underlying contract; the savepoint per insert
+in the controller is what lets one duplicate co-exist with accepted
+events in the same batch.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from litestar.testing import AsyncTestClient
+
+
+_HLC_A = "0000000000000001-00000-client-a"
+_HLC_B = "0000000000000002-00000-client-a"
+
+
+def _event(hlc: str, *, instance_id: str | None = None) -> dict[str, object]:
+    return {
+        "hlc": hlc,
+        "family": "asset",
+        "type_id": str(uuid4()),
+        "instance_id": instance_id or str(uuid4()),
+        "body": {"event": "created", "values": {"col:name": "x"}},
+    }
+
+
+async def test_fresh_batch_returns_all_accepted(client: AsyncTestClient) -> None:
+    resp = await client.post(
+        "/events",
+        json={
+            "schema_version": 0,
+            "events": [_event(_HLC_A), _event(_HLC_B)],
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    outcomes = resp.json()["outcomes"]
+    assert [o["outcome"] for o in outcomes] == ["accepted", "accepted"]
+
+
+async def test_replay_same_batch_returns_all_duplicate(
+    client: AsyncTestClient,
+) -> None:
+    body = {"schema_version": 0, "events": [_event(_HLC_A), _event(_HLC_B)]}
+    first = await client.post("/events", json=body)
+    assert first.status_code == 202, first.text
+    second = await client.post("/events", json=body)
+    assert second.status_code == 202, second.text
+    outcomes = second.json()["outcomes"]
+    assert [o["outcome"] for o in outcomes] == ["duplicate", "duplicate"]
+
+
+async def test_partial_replay_returns_mixed_outcomes(client: AsyncTestClient) -> None:
+    # First batch: only HLC_A.
+    first = await client.post(
+        "/events", json={"schema_version": 0, "events": [_event(_HLC_A)]}
+    )
+    assert first.status_code == 202, first.text
+    # Second batch: HLC_A (duplicate) followed by HLC_B (fresh).
+    second = await client.post(
+        "/events",
+        json={"schema_version": 0, "events": [_event(_HLC_A), _event(_HLC_B)]},
+    )
+    assert second.status_code == 202, second.text
+    outcomes = second.json()["outcomes"]
+    assert [o["outcome"] for o in outcomes] == ["duplicate", "accepted"]
+
+
+async def test_rejection_does_not_consume_an_hlc(client: AsyncTestClient) -> None:
+    # A rejected event must not occupy the (tenant_id, hlc) slot —
+    # later, a fixed version of the same wire-event should be able to
+    # append successfully without colliding.
+    bad_value_event = {
+        "hlc": _HLC_A,
+        "family": "asset",
+        "type_id": str(uuid4()),
+        "instance_id": str(uuid4()),
+        # "col:bogus" is unknown_field — rejected, not stored.
+        "body": {"event": "created", "values": {"col:bogus": "x"}},
+    }
+    first = await client.post(
+        "/events", json={"schema_version": 0, "events": [bad_value_event]}
+    )
+    assert first.status_code == 202, first.text
+    assert first.json()["outcomes"][0]["outcome"] == "rejected:unknown_field"
+
+    # The same HLC is now free for a valid event.
+    second = await client.post(
+        "/events", json={"schema_version": 0, "events": [_event(_HLC_A)]}
+    )
+    assert second.status_code == 202, second.text
+    assert second.json()["outcomes"][0]["outcome"] == "accepted"

--- a/tests/events/test_endpoint_scaffold.py
+++ b/tests/events/test_endpoint_scaffold.py
@@ -1,11 +1,11 @@
-"""Scaffold-level tests for ``POST /events`` (M1.1)."""
+"""Smoke tests for ``POST /events`` (M1.1 scaffold + M1.5 outcomes)."""
 
 from __future__ import annotations
 
 from uuid import uuid4
 
 
-async def test_post_events_returns_202_for_valid_batch(client) -> None:
+async def test_post_events_returns_202_with_accepted_outcome(client) -> None:
     resp = await client.post(
         "/events",
         json={
@@ -25,13 +25,18 @@ async def test_post_events_returns_202_for_valid_batch(client) -> None:
         },
     )
     assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body == {
+        "outcomes": [
+            {"hlc": "0001700000000000-00000-abc", "outcome": "accepted"},
+        ]
+    }
 
 
 async def test_post_events_accepts_empty_batch(client) -> None:
-    # Empty batches are syntactically valid; this issue is scaffold-only
-    # and explicitly defers all validation to later milestones (M1.2+).
     resp = await client.post(
         "/events",
         json={"schema_version": 0, "events": []},
     )
     assert resp.status_code == 202, resp.text
+    assert resp.json() == {"outcomes": []}

--- a/tests/events/test_endpoint_validation.py
+++ b/tests/events/test_endpoint_validation.py
@@ -1,4 +1,10 @@
-"""End-to-end tests for per-event schema validation on POST /events (M1.4)."""
+"""End-to-end tests for per-event schema validation on POST /events (M1.4 + M1.5).
+
+Per-event validation failures (unknown_field, value_type_mismatch,
+invalid_payload_shape) surface as ``rejected:<code>`` entries in the
+outcome list; the HTTP envelope still returns 202 (M1.5 acceptance
+criteria — one rejected event must not poison the batch).
+"""
 
 from __future__ import annotations
 
@@ -17,10 +23,6 @@ async def _seed_asset_type_with_field(
     *,
     field_data_type: str = "text",
 ) -> tuple[str, str, int]:
-    """Create one asset type + one field via POST /schema.
-
-    Returns ``(type_id, field_id, schema_version)``.
-    """
     type_id = str(uuid4())
     field_id = str(uuid4())
     resp = await client.post(
@@ -65,45 +67,47 @@ def _event(
     }
 
 
+async def _post_one(
+    client: AsyncTestClient, schema_version: int, event: dict[str, object]
+) -> dict[str, object]:
+    """Post a one-event batch; return the single outcome."""
+    resp = await client.post(
+        "/events", json={"schema_version": schema_version, "events": [event]}
+    )
+    assert resp.status_code == 202, resp.text
+    outcomes = resp.json()["outcomes"]
+    assert len(outcomes) == 1
+    return outcomes[0]
+
+
 async def test_known_user_field_with_correct_type_is_accepted(
     client: AsyncTestClient,
 ) -> None:
     type_id, field_id, schema_version = await _seed_asset_type_with_field(client)
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={field_id: "ABC123"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={field_id: "ABC123"}),
     )
-    assert resp.status_code == 202, resp.text
+    assert outcome["outcome"] == "accepted"
 
 
-async def test_unknown_user_field_returns_404_unknown_field(
+async def test_unknown_user_field_rejects_unknown_field(
     client: AsyncTestClient,
 ) -> None:
     type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
     bogus_field_id = str(uuid4())
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={bogus_field_id: "x"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={bogus_field_id: "x"}),
     )
-    assert resp.status_code == 404, resp.text
-    body = resp.json()
-    assert body["type"] == "http://test/problems/unknown_field.html"
-    assert body["title"] == "Unknown field"
-    assert body["field"] == bogus_field_id
-    assert body["family"] == "asset"
-    assert body["type_id"] == type_id
+    assert outcome["outcome"] == "rejected:unknown_field"
 
 
 async def test_field_under_different_type_reported_as_unknown(
     client: AsyncTestClient,
 ) -> None:
-    # Field exists, but the event addresses a *different* asset type.
     _type_id_a, field_id, schema_version_a = await _seed_asset_type_with_field(client)
     type_id_b = str(uuid4())
     resp = await client.post(
@@ -118,24 +122,16 @@ async def test_field_under_different_type_reported_as_unknown(
     schema_version_b = int(resp.json()["schema_version"])
     assert schema_version_b > schema_version_a
 
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version_b,
-            # type_id_b has no fields of its own; field_id belongs to type_id_a.
-            "events": [_event(type_id=type_id_b, values={field_id: "x"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version_b,
+        _event(type_id=type_id_b, values={field_id: "x"}),
     )
-    assert resp.status_code == 404, resp.text
-    assert resp.json()["type"] == "http://test/problems/unknown_field.html"
+    assert outcome["outcome"] == "rejected:unknown_field"
 
 
 async def test_deactivated_field_is_still_accepted(client: AsyncTestClient) -> None:
-    # ADR-012 keeps the data fold decoupled from schema visibility:
-    # events for a deactivated (but undeleted) field must still land.
-    type_id, field_id, _schema_version_after_create = await _seed_asset_type_with_field(
-        client
-    )
+    type_id, field_id, _ = await _seed_asset_type_with_field(client)
     resp = await client.post(
         "/schema",
         json={
@@ -146,152 +142,109 @@ async def test_deactivated_field_is_still_accepted(client: AsyncTestClient) -> N
     assert resp.status_code in (200, 201), resp.text
     schema_version_after_deactivate = int(resp.json()["schema_version"])
 
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version_after_deactivate,
-            "events": [_event(type_id=type_id, values={field_id: "still works"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version_after_deactivate,
+        _event(type_id=type_id, values={field_id: "still works"}),
     )
-    assert resp.status_code == 202, resp.text
+    assert outcome["outcome"] == "accepted"
 
 
-async def test_value_type_mismatch_returns_400(client: AsyncTestClient) -> None:
+async def test_value_type_mismatch_rejects_with_code(client: AsyncTestClient) -> None:
     type_id, field_id, schema_version = await _seed_asset_type_with_field(
         client, field_data_type="integer"
     )
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={field_id: "not-a-number"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={field_id: "not-a-number"}),
     )
-    assert resp.status_code == 400, resp.text
-    body = resp.json()
-    assert body["type"] == "http://test/problems/value_type_mismatch.html"
-    assert body["field"] == field_id
-    assert body["expected"] == "integer"
-    assert body["received"] == "string"
+    assert outcome["outcome"] == "rejected:value_type_mismatch"
 
 
 async def test_null_value_is_always_accepted(client: AsyncTestClient) -> None:
-    # null is the cell-clearing sentinel; valid against any data_type.
     type_id, field_id, schema_version = await _seed_asset_type_with_field(
         client, field_data_type="integer"
     )
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [
-                {
-                    "hlc": _VALID_HLC,
-                    "family": "asset",
-                    "type_id": type_id,
-                    "instance_id": str(uuid4()),
-                    "body": {"event": "updated", "values": {field_id: None}},
-                }
-            ],
+    outcome = await _post_one(
+        client,
+        schema_version,
+        {
+            "hlc": _VALID_HLC,
+            "family": "asset",
+            "type_id": type_id,
+            "instance_id": str(uuid4()),
+            "body": {"event": "updated", "values": {field_id: None}},
         },
     )
-    assert resp.status_code == 202, resp.text
+    assert outcome["outcome"] == "accepted"
 
 
 async def test_col_name_accepts_text(client: AsyncTestClient) -> None:
     type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={"col:name": "Truck-7"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={"col:name": "Truck-7"}),
     )
-    assert resp.status_code == 202, resp.text
+    assert outcome["outcome"] == "accepted"
 
 
 async def test_col_name_rejects_wrong_type(client: AsyncTestClient) -> None:
     type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={"col:name": 42})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={"col:name": 42}),
     )
-    assert resp.status_code == 400, resp.text
-    body = resp.json()
-    assert body["type"] == "http://test/problems/value_type_mismatch.html"
-    assert body["field"] == "col:name"
-    assert body["expected"] == "text"
-    assert body["received"] == "integer"
+    assert outcome["outcome"] == "rejected:value_type_mismatch"
 
 
 async def test_unknown_col_returns_unknown_field(client: AsyncTestClient) -> None:
     type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={"col:bogus": "x"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={"col:bogus": "x"}),
     )
-    assert resp.status_code == 404, resp.text
-    body = resp.json()
-    assert body["type"] == "http://test/problems/unknown_field.html"
-    assert body["field"] == "col:bogus"
+    assert outcome["outcome"] == "rejected:unknown_field"
 
 
 async def test_reserved_col_is_invalid_payload_shape(client: AsyncTestClient) -> None:
     type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={"col:deleted": True})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={"col:deleted": True}),
     )
-    assert resp.status_code == 400, resp.text
-    body = resp.json()
-    assert body["type"] == "http://test/problems/invalid_payload_shape.html"
+    assert outcome["outcome"] == "rejected:invalid_payload_shape"
 
 
 async def test_non_uuid_non_col_key_is_invalid_payload_shape(
     client: AsyncTestClient,
 ) -> None:
     type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [_event(type_id=type_id, values={"not-a-uuid": "x"})],
-        },
+    outcome = await _post_one(
+        client,
+        schema_version,
+        _event(type_id=type_id, values={"not-a-uuid": "x"}),
     )
-    assert resp.status_code == 400, resp.text
-    body = resp.json()
-    assert body["type"] == "http://test/problems/invalid_payload_shape.html"
+    assert outcome["outcome"] == "rejected:invalid_payload_shape"
 
 
 async def test_deactivated_or_activated_event_has_no_value_validation(
     client: AsyncTestClient,
 ) -> None:
-    # Row-state events carry no body.values, so the per-field validator
-    # is a no-op. Sanity-check that they still reach the 202 path even
-    # against a schema that has been bumped.
     type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
-    resp = await client.post(
-        "/events",
-        json={
-            "schema_version": schema_version,
-            "events": [
-                {
-                    "hlc": _VALID_HLC,
-                    "family": "asset",
-                    "type_id": type_id,
-                    "instance_id": str(uuid4()),
-                    "body": {"event": "deactivated"},
-                }
-            ],
+    outcome = await _post_one(
+        client,
+        schema_version,
+        {
+            "hlc": _VALID_HLC,
+            "family": "asset",
+            "type_id": type_id,
+            "instance_id": str(uuid4()),
+            "body": {"event": "deactivated"},
         },
     )
-    assert resp.status_code == 202, resp.text
+    assert outcome["outcome"] == "accepted"

--- a/tests/events/test_endpoint_validation.py
+++ b/tests/events/test_endpoint_validation.py
@@ -8,7 +8,7 @@ criteria — one rejected event must not poison the batch).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -69,7 +69,7 @@ def _event(
 
 async def _post_one(
     client: AsyncTestClient, schema_version: int, event: dict[str, object]
-) -> dict[str, object]:
+) -> dict[str, Any]:
     """Post a one-event batch; return the single outcome."""
     resp = await client.post(
         "/events", json={"schema_version": schema_version, "events": [event]}
@@ -103,6 +103,14 @@ async def test_unknown_user_field_rejects_unknown_field(
         _event(type_id=type_id, values={bogus_field_id: "x"}),
     )
     assert outcome["outcome"] == "rejected:unknown_field"
+    # The exception's extras must reach the wire — without them clients
+    # cannot diagnose which field on which type was unrecognised.
+    problem = outcome["problem"]
+    assert problem["type"].endswith("/problems/unknown_field.html")
+    assert problem["status"] == 404
+    assert problem["family"] == "asset"
+    assert problem["type_id"] == type_id
+    assert problem["field"] == bogus_field_id
 
 
 async def test_field_under_different_type_reported_as_unknown(
@@ -160,6 +168,12 @@ async def test_value_type_mismatch_rejects_with_code(client: AsyncTestClient) ->
         _event(type_id=type_id, values={field_id: "not-a-number"}),
     )
     assert outcome["outcome"] == "rejected:value_type_mismatch"
+    problem = outcome["problem"]
+    assert problem["type"].endswith("/problems/value_type_mismatch.html")
+    assert problem["status"] == 400
+    assert problem["field"] == field_id
+    assert problem["expected"] == "integer"
+    assert problem["received"] == "string"
 
 
 async def test_null_value_is_always_accepted(client: AsyncTestClient) -> None:

--- a/tests/events/test_handlers_asset.py
+++ b/tests/events/test_handlers_asset.py
@@ -22,6 +22,7 @@ from novamoc.domain.events._payloads import (
     EventEnvelope,
     Updated,
 )
+from novamoc.domain.events.services import EventLogService
 from novamoc.domain.schema.services import (
     AssetTypeFieldService,
     MaintenanceRecordTypeFieldService,
@@ -49,6 +50,8 @@ def event_services(session: AsyncSession) -> EventServiceBundle:
         maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
             session=session
         ),
+        event_log_service=EventLogService(session=session),
+        schema_version=0,
     )
 
 
@@ -110,11 +113,13 @@ async def test_updated_validates_like_created(
     await asset.updated(event_services, _auth(), _envelope(type_id, body))
 
 
-async def test_deactivated_is_noop(event_services: EventServiceBundle) -> None:
+async def test_deactivated_appends(event_services: EventServiceBundle) -> None:
     body = Deactivated()
-    await asset.deactivated(event_services, _auth(), _envelope(uuid4(), body))
+    outcome = await asset.deactivated(event_services, _auth(), _envelope(uuid4(), body))
+    assert outcome.outcome == "accepted"
 
 
-async def test_activated_is_noop(event_services: EventServiceBundle) -> None:
+async def test_activated_appends(event_services: EventServiceBundle) -> None:
     body = Activated()
-    await asset.activated(event_services, _auth(), _envelope(uuid4(), body))
+    outcome = await asset.activated(event_services, _auth(), _envelope(uuid4(), body))
+    assert outcome.outcome == "accepted"

--- a/tests/events/test_handlers_maintenance_record.py
+++ b/tests/events/test_handlers_maintenance_record.py
@@ -22,6 +22,7 @@ from novamoc.domain.events._payloads import (
     EventEnvelope,
     Updated,
 )
+from novamoc.domain.events.services import EventLogService
 from novamoc.domain.schema.services import (
     AssetTypeFieldService,
     MaintenanceRecordTypeFieldService,
@@ -49,6 +50,8 @@ def event_services(session: AsyncSession) -> EventServiceBundle:
         maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
             session=session
         ),
+        event_log_service=EventLogService(session=session),
+        schema_version=0,
     )
 
 
@@ -114,15 +117,17 @@ async def test_updated_validates_like_created(
     await maintenance_record.updated(event_services, _auth(), _envelope(type_id, body))
 
 
-async def test_deactivated_is_noop(event_services: EventServiceBundle) -> None:
+async def test_deactivated_appends(event_services: EventServiceBundle) -> None:
     body = Deactivated()
-    await maintenance_record.deactivated(
+    outcome = await maintenance_record.deactivated(
         event_services, _auth(), _envelope(uuid4(), body)
     )
+    assert outcome.outcome == "accepted"
 
 
-async def test_activated_is_noop(event_services: EventServiceBundle) -> None:
+async def test_activated_appends(event_services: EventServiceBundle) -> None:
     body = Activated()
-    await maintenance_record.activated(
+    outcome = await maintenance_record.activated(
         event_services, _auth(), _envelope(uuid4(), body)
     )
+    assert outcome.outcome == "accepted"


### PR DESCRIPTION
Closes #24.

## Summary
- M1.5 of the event-sync endpoint (closes #24, ADR-011). Validated events are appended to `event_log`; the response now carries per-event outcomes so a batch can have mixed `accepted` / `duplicate` / `rejected:<code>` results without poisoning unaffected events.
- **Per-event vs batch semantics.** Per-event validation failures (HLC drift, unknown field, type mismatch, malformed HLC) now surface as in-band `rejected:<code>` outcomes — the HTTP envelope stays 202. Batch-level failures (`schema_version_stale`, malformed wire) still return `application/problem+json` with 4xx.
- **Idempotent retry.** A retried event whose `(tenant_id, hlc)` collides with an existing row returns `duplicate`. Inserts run inside `session.begin_nested()` so an `IntegrityError` on one event leaves the surrounding transaction usable for the next; the catch targets `advanced_alchemy.exceptions.IntegrityError` (the wrapper around SQLAlchemy's, which `SQLAlchemyAsyncRepositoryService.create` raises).
- **DI bundling.** Four services + the drift tunable are wrapped in an `AppendDeps` dataclass and provided through a single `Provide(_provide_append_deps)` — the handler signature stays at `(self, data, deps)`, avoiding the PLR0913 ratchet bump from a four-service injection.
- **Storage shape.** Event-grain for now: one `event_log` row per wire-event with the body as a msgspec dict in `value_json` and `field_id=NULL`. The EAV-grain decomposition ADR-012 describes lands with the projection-fold work in M1.6/M1.7 where field-grain rows actually become useful.
- Pre-existing event endpoint tests updated for the new outcome envelope.

> ⚠️ Stacked on #64 (M1.4). Base auto-retargets when #64 merges.

## Test plan
- [x] Scaffold + matching-version path returns 202 with single `accepted` outcome.
- [x] Drift / malformed-HLC / unknown-field / value-type-mismatch surface as `rejected:<code>` (202 envelope).
- [x] Mixed batch (good + bad + good) lists each outcome independently — neighbours not poisoned.
- [x] Full replay of accepted batch returns all-`duplicate`.
- [x] Partial replay returns mixed `duplicate` + `accepted`.
- [x] Rejected event does not consume its HLC: a valid event with the same HLC posted afterwards is `accepted`.
- [x] `schema_version_stale` remains a 409 batch-level rejection.
- [x] `just check` clean — 266 tests, ratchet at 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
