### PR TITLE
docs(adr): accept ADR-006 (HLC) and ADR-007 (per-field LWW)

### DIFF
--- a/docs/adr/006-hybrid-logical-clocks.md
+++ b/docs/adr/006-hybrid-logical-clocks.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/007-per-field-last-write-wins.md
+++ b/docs/adr/007-per-field-last-write-wins.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
Closes #29.

## Summary
- M1.10 of the Pass 2 ADR-acceptance plan (closes #29). The data-write milestone (M1.1–M1.9) has implemented both ADRs end-to-end, so flip them from Proposed → Accepted.
- **ADR-006 (HLC)** shipped with HLC parse + drift validation in M1.2 (#21) and the strict-greater HLC comparison used by both the field-value fold (#25) and the row-state apply (#27).
- **ADR-007 (per-field LWW)** shipped with the field-value fold in M1.6 (#25). The same strict-greater rule extends to row-state in M1.8 (#27).
- **ADR-011 / ADR-012** were already Accepted in Pass 1 (commit 6e7738e). The prose still matches what shipped — no status change needed.
- **ADR-009 stays Proposed.** M1.3's schema-version gate (#22) covers the write-side enforcement, but the read-side schema catch-up flow lands with the M2 read endpoints. ADR-009 is the next promotion candidate.

> ⚠️ Stacked on #70 (M1.9). Base auto-retargets when #70 merges. With this merged, the whole M1 chain (#62 → #63 → #64 → #66 → #67 → #68 → #69 → #70 → this) closes Milestone 1.

## Test plan
- [x] ADR-006 Status line reads `Accepted`.
- [x] ADR-007 Status line reads `Accepted`.
- [x] ADR-009 Status line still reads `Proposed`.
- [x] `just check` clean — 300 tests, ratchet at 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
