### PR TITLE
M4.2 — read-only schema browser

### DIFF
--- a/src/js/web/src/App.svelte
+++ b/src/js/web/src/App.svelte
@@ -1,101 +1,44 @@
 <script lang="ts">
-  import { createApiClient, ProblemDetailsError } from './lib/api'
+  import SchemaBrowser from './lib/SchemaBrowser.svelte'
   import { getBearerToken, setBearerToken } from './lib/token'
 
-  type ProbeResult =
-    | { kind: 'success'; body: unknown }
-    | { kind: 'error'; status: number; code: string; body: unknown }
-
   let token = $state(getBearerToken() ?? '')
-  let result = $state<ProbeResult | null>(null)
-  let loading = $state(false)
+  let reloadKey = $state(0)
 
-  function syncToken(): void {
+  function applyToken(): void {
     setBearerToken(token === '' ? null : token)
-  }
-
-  async function runProbe(client: ReturnType<typeof createApiClient>): Promise<void> {
-    loading = true
-    result = null
-    try {
-      const body = await client.get('/schema')
-      result = { kind: 'success', body }
-    } catch (e) {
-      if (e instanceof ProblemDetailsError) {
-        result = { kind: 'error', status: e.status, code: e.code, body: e.body }
-      } else {
-        result = { kind: 'error', status: 0, code: 'network_error', body: String(e) }
-      }
-    } finally {
-      loading = false
-    }
-  }
-
-  function probeSuccess(): void {
-    void runProbe(createApiClient())
-  }
-
-  function probeError(): void {
-    void runProbe(createApiClient({ getToken: () => 'invalid-token' }))
+    reloadKey += 1
   }
 </script>
 
-<main class="mx-auto max-w-3xl p-8">
+<main class="mx-auto max-w-5xl p-8">
   <header class="mb-6">
     <h1 class="text-3xl font-bold">novaMOC</h1>
-    <p class="text-sm text-gray-600">M4.1 — bearer-token + API client smoke test</p>
+    <p class="text-sm text-gray-600">Schema browser</p>
   </header>
 
-  <section class="mb-6">
-    <label for="bearer-token" class="mb-1 block text-sm font-medium">Bearer token</label>
-    <input
-      id="bearer-token"
-      type="text"
-      class="w-full rounded border border-gray-300 px-3 py-2 font-mono text-sm"
-      placeholder="(empty — falls back to VITE_DEFAULT_BEARER_TOKEN)"
-      bind:value={token}
-      onblur={syncToken}
-    />
+  <section class="mb-8">
+    <label for="bearer-token" class="mb-1 block text-sm font-medium">
+      Bearer token
+    </label>
+    <div class="flex gap-2">
+      <input
+        id="bearer-token"
+        type="text"
+        class="flex-1 rounded border border-gray-300 px-3 py-2 font-mono text-sm"
+        placeholder="(empty — falls back to VITE_DEFAULT_BEARER_TOKEN)"
+        bind:value={token}
+        onblur={applyToken}
+      />
+      <button
+        type="button"
+        class="rounded bg-blue-600 px-4 py-2 text-sm text-white"
+        onclick={applyToken}
+      >
+        Apply
+      </button>
+    </div>
   </section>
 
-  <section class="mb-6 flex gap-3">
-    <button
-      type="button"
-      class="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
-      disabled={loading}
-      onclick={probeSuccess}
-    >
-      Probe success (GET /schema)
-    </button>
-    <button
-      type="button"
-      class="rounded bg-gray-700 px-4 py-2 text-white disabled:opacity-50"
-      disabled={loading}
-      onclick={probeError}
-    >
-      Probe error (bad token &rarr; 401)
-    </button>
-  </section>
-
-  {#if result !== null}
-    <section class="rounded border border-gray-200 p-4">
-      {#if result.kind === 'success'}
-        <h2 class="mb-2 text-lg font-semibold text-green-700">Success</h2>
-        <pre class="overflow-x-auto rounded bg-gray-50 p-3 text-xs">{JSON.stringify(
-            result.body,
-            null,
-            2,
-          )}</pre>
-      {:else}
-        <h2 class="mb-2 text-lg font-semibold text-red-700">
-          {result.status} &middot; {result.code}
-        </h2>
-        <pre class="overflow-x-auto rounded bg-gray-50 p-3 text-xs">{JSON.stringify(
-            result.body,
-            null,
-            2,
-          )}</pre>
-      {/if}
-    </section>
-  {/if}
+  <SchemaBrowser {reloadKey} />
 </main>

--- a/src/js/web/src/lib/SchemaBrowser.svelte
+++ b/src/js/web/src/lib/SchemaBrowser.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { createApiClient, ProblemDetailsError } from './api'
+  import { fetchSchema, type SchemaSnapshot, type TypeView } from './schema'
+  import TypeCard from './TypeCard.svelte'
+
+  interface Props {
+    /** Bump from outside to force a re-fetch (e.g. after the token changes). */
+    reloadKey?: number
+  }
+
+  let { reloadKey = 0 }: Props = $props()
+
+  type LoadState =
+    | { kind: 'idle' }
+    | { kind: 'loading' }
+    | { kind: 'loaded'; snapshot: SchemaSnapshot }
+    | { kind: 'error'; status: number; code: string; message: string }
+
+  let loadState: LoadState = $state({ kind: 'idle' })
+  let showTombstoned = $state(false)
+
+  function visibleTypes(types: TypeView[]): TypeView[] {
+    return showTombstoned ? types : types.filter((t) => t.active)
+  }
+
+  async function load(): Promise<void> {
+    loadState = { kind: 'loading' }
+    try {
+      const snapshot = await fetchSchema(createApiClient())
+      loadState = { kind: 'loaded', snapshot }
+    } catch (e) {
+      if (e instanceof ProblemDetailsError) {
+        loadState = {
+          kind: 'error',
+          status: e.status,
+          code: e.code,
+          message: e.message,
+        }
+      } else {
+        loadState = {
+          kind: 'error',
+          status: 0,
+          code: 'network_error',
+          message: String(e),
+        }
+      }
+    }
+  }
+
+  $effect(() => {
+    reloadKey
+    void load()
+  })
+</script>
+
+<section class="space-y-6">
+  <div class="flex items-center justify-between">
+    <div>
+      <h2 class="text-xl font-semibold">Schema</h2>
+      {#if loadState.kind === 'loaded'}
+        <p class="text-xs text-gray-500">
+          version {loadState.snapshot.schema_version}
+        </p>
+      {/if}
+    </div>
+    <div class="flex items-center gap-3">
+      <label class="flex items-center gap-2 text-sm">
+        <input type="checkbox" bind:checked={showTombstoned} />
+        <span>Show tombstoned</span>
+      </label>
+      <button
+        type="button"
+        class="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-50 disabled:opacity-50"
+        disabled={loadState.kind === 'loading'}
+        onclick={() => void load()}
+      >
+        {loadState.kind === 'loading' ? 'Loading…' : 'Reload'}
+      </button>
+    </div>
+  </div>
+
+  {#if loadState.kind === 'loading'}
+    <p class="text-sm text-gray-600">Loading schema…</p>
+  {:else if loadState.kind === 'error'}
+    <div class="rounded border border-red-300 bg-red-50 p-4">
+      <p class="text-sm font-semibold text-red-700">
+        {loadState.status} · {loadState.code}
+      </p>
+      <p class="mt-1 text-sm text-red-700">{loadState.message}</p>
+    </div>
+  {:else if loadState.kind === 'loaded'}
+    {@const assetTypes = visibleTypes(loadState.snapshot.asset_types)}
+    {@const recordTypes = visibleTypes(loadState.snapshot.maintenance_record_types)}
+    <div class="grid gap-8 md:grid-cols-2">
+      <div>
+        <h3 class="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-600">
+          Asset types ({assetTypes.length})
+        </h3>
+        {#if assetTypes.length === 0}
+          <p class="text-sm italic text-gray-500">
+            no {showTombstoned ? '' : 'active '}asset types
+          </p>
+        {:else}
+          <div class="space-y-3">
+            {#each assetTypes as type (type.id)}
+              <TypeCard {type} {showTombstoned} />
+            {/each}
+          </div>
+        {/if}
+      </div>
+      <div>
+        <h3 class="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-600">
+          Maintenance record types ({recordTypes.length})
+        </h3>
+        {#if recordTypes.length === 0}
+          <p class="text-sm italic text-gray-500">
+            no {showTombstoned ? '' : 'active '}maintenance record types
+          </p>
+        {:else}
+          <div class="space-y-3">
+            {#each recordTypes as type (type.id)}
+              <TypeCard {type} {showTombstoned} />
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+</section>

--- a/src/js/web/src/lib/TypeCard.svelte
+++ b/src/js/web/src/lib/TypeCard.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import type { TypeView } from './schema'
+
+  interface Props {
+    type: TypeView
+    showTombstoned: boolean
+  }
+
+  let { type, showTombstoned }: Props = $props()
+
+  let visibleFields = $derived(
+    showTombstoned ? type.fields : type.fields.filter((f) => f.active),
+  )
+</script>
+
+<article
+  class="rounded border border-gray-200 p-4"
+  class:opacity-60={!type.active}
+>
+  <header class="mb-3 flex items-baseline justify-between gap-2">
+    <h3 class="font-mono text-base font-semibold">{type.name}</h3>
+    {#if !type.active}
+      <span
+        class="rounded bg-gray-200 px-2 py-0.5 text-xs uppercase tracking-wide text-gray-700"
+      >
+        tombstoned
+      </span>
+    {/if}
+  </header>
+
+  {#if visibleFields.length === 0}
+    <p class="text-sm italic text-gray-500">
+      {#if type.fields.length === 0}
+        no fields
+      {:else}
+        no active fields
+      {/if}
+    </p>
+  {:else}
+    <ul class="divide-y divide-gray-100">
+      {#each visibleFields as field (field.id)}
+        <li
+          class="flex items-center justify-between py-1.5 text-sm"
+          class:opacity-60={!field.active}
+        >
+          <span class="font-mono">{field.name}</span>
+          <span class="flex items-center gap-2">
+            <span class="text-xs uppercase tracking-wide text-gray-500">
+              {field.data_type}
+            </span>
+            {#if !field.active}
+              <span
+                class="rounded bg-gray-200 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-gray-700"
+              >
+                tombstoned
+              </span>
+            {/if}
+          </span>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</article>

--- a/src/js/web/src/lib/schema.ts
+++ b/src/js/web/src/lib/schema.ts
@@ -1,0 +1,42 @@
+/**
+ * Typed wire-format for ``GET /schema`` (M4.2).
+ *
+ * Mirrors :class:`novamoc.domain.schema._read_payloads.SchemaSnapshotResponse`.
+ * Tombstoned entries (``active=false``) are included; the UI filters them at
+ * render time per ADR-008 / ADR-009.
+ */
+
+import type { ApiClient } from './api'
+
+export type FieldDataType =
+  | 'text'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'date'
+  | 'datetime'
+
+export interface FieldView {
+  id: string
+  name: string
+  data_type: FieldDataType
+  validation: Record<string, unknown> | null
+  active: boolean
+}
+
+export interface TypeView {
+  id: string
+  name: string
+  active: boolean
+  fields: FieldView[]
+}
+
+export interface SchemaSnapshot {
+  schema_version: number
+  asset_types: TypeView[]
+  maintenance_record_types: TypeView[]
+}
+
+export function fetchSchema(client: ApiClient): Promise<SchemaSnapshot> {
+  return client.get<SchemaSnapshot>('/schema')
+}


### PR DESCRIPTION
## Summary

- Adds a Svelte 5 schema browser to ``src/js/web/`` that calls ``GET /schema`` via the M4.1 typed API client and renders the four type lists: asset types and maintenance record types with their nested fields.
- Tombstoned (``active=false``) entries are included in the response shape; the UI toggles their visibility (default hidden) per ADR-008/ADR-009 so the same snapshot stays reusable once write paths land.
- Bearer-token input stays at the top of the page; ``App.svelte`` bumps a ``reloadKey`` after Apply and the browser ``$effect`` reads it to re-fetch.
- Problem-details errors render with ``status · code``; the network-error path renders as ``0 · network_error``.

## Test plan

- [x] ``cd src/js/web && npm run check`` — 0 errors, 0 warnings
- [x] Svelte MCP autofixer on the three new files — 0 issues
- [x] ``cd src/js/web && npm run build`` — production bundle builds cleanly
- [x] ``just check`` — 298 pytest tests pass, ratchet unchanged
- [x] ``curl`` through the Vite proxy: ``GET /schema`` with the dev bearer → 200 + snapshot; bad bearer → 401 ``tenant_not_resolved``
- [ ] Browser-driven Playwright smoke — deferred behind the same chrome-path blocker M4.1 hit; tracked separately, no regression

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)