### PR TITLE
feat(web): M4.4 — asset-type-field lifecycle forms

### DIFF
--- a/src/js/web/src/lib/AssetTypeFieldActions.svelte
+++ b/src/js/web/src/lib/AssetTypeFieldActions.svelte
@@ -1,0 +1,255 @@
+<script lang="ts">
+  import { createApiClient, ProblemDetailsError } from './api'
+  import { postSchemaCommand, type SchemaCommandBody } from './commands'
+  import type { FieldView } from './schema'
+
+  interface Props {
+    field: FieldView
+    onChanged: () => void
+  }
+
+  let { field, onChanged }: Props = $props()
+
+  type Mode =
+    | { kind: 'idle' }
+    | { kind: 'renaming'; draft: string }
+    | { kind: 'confirming_clear' }
+    | { kind: 'confirming_delete' }
+    | { kind: 'submitting' }
+    | { kind: 'error'; status: number; code: string; message: string }
+
+  let mode = $state<Mode>({ kind: 'idle' })
+
+  function reset(): void {
+    mode = { kind: 'idle' }
+  }
+
+  function startRename(): void {
+    mode = { kind: 'renaming', draft: field.name }
+  }
+
+  function startConfirmClear(): void {
+    mode = { kind: 'confirming_clear' }
+  }
+
+  function startConfirmDelete(): void {
+    mode = { kind: 'confirming_delete' }
+  }
+
+  async function send(body: SchemaCommandBody): Promise<void> {
+    mode = { kind: 'submitting' }
+    try {
+      await postSchemaCommand(createApiClient(), body)
+      reset()
+      onChanged()
+    } catch (e) {
+      if (e instanceof ProblemDetailsError) {
+        mode = {
+          kind: 'error',
+          status: e.status,
+          code: e.code,
+          message: e.message,
+        }
+      } else {
+        mode = {
+          kind: 'error',
+          status: 0,
+          code: 'network_error',
+          message: String(e),
+        }
+      }
+    }
+  }
+
+  function submitRename(event: SubmitEvent): void {
+    event.preventDefault()
+    if (mode.kind !== 'renaming') return
+    const draft = mode.draft.trim()
+    if (draft === '' || draft === field.name) return
+    void send({
+      type: 'update_asset_type_field',
+      entity_id: field.id,
+      payload: { name: draft },
+    })
+  }
+
+  function activate(): void {
+    void send({
+      type: 'activate_asset_type_field',
+      entity_id: field.id,
+      payload: {},
+    })
+  }
+
+  function deactivate(): void {
+    void send({
+      type: 'deactivate_asset_type_field',
+      entity_id: field.id,
+      payload: {},
+    })
+  }
+
+  function confirmClear(): void {
+    void send({
+      type: 'clear_asset_type_field',
+      entity_id: field.id,
+      payload: {},
+    })
+  }
+
+  function confirmDelete(): void {
+    void send({
+      type: 'delete_asset_type_field',
+      entity_id: field.id,
+      payload: {},
+    })
+  }
+
+  let nameError = $derived(
+    mode.kind === 'error' && mode.code === 'name_reserved',
+  )
+  let busy = $derived(mode.kind === 'submitting')
+</script>
+
+<div class="mt-1 space-y-1">
+  {#if mode.kind === 'renaming'}
+    <form class="flex items-end gap-2" onsubmit={submitRename}>
+      <div class="flex-1">
+        <label
+          for="rename-field-{field.id}"
+          class="block text-[10px] font-medium text-gray-700"
+        >
+          New name
+        </label>
+        <input
+          id="rename-field-{field.id}"
+          type="text"
+          class="mt-0.5 w-full rounded border px-2 py-0.5 font-mono text-xs"
+          class:border-gray-300={!nameError}
+          class:border-red-500={nameError}
+          class:ring-1={nameError}
+          class:ring-red-500={nameError}
+          bind:value={mode.draft}
+          required
+        />
+      </div>
+      <button
+        type="button"
+        class="rounded border border-gray-300 px-2 py-0.5 text-xs hover:bg-gray-50"
+        onclick={reset}
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        class="rounded bg-blue-600 px-2 py-0.5 text-xs text-white disabled:opacity-50"
+        disabled={mode.draft.trim() === '' || mode.draft.trim() === field.name}
+      >
+        Save
+      </button>
+    </form>
+  {:else if mode.kind === 'confirming_clear'}
+    <div
+      class="flex items-center justify-between rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800"
+    >
+      <span>Clear values for <span class="font-mono">{field.name}</span>?</span>
+      <span class="flex gap-2">
+        <button
+          type="button"
+          class="rounded border border-amber-300 bg-white px-2 py-0.5 text-[10px] hover:bg-amber-100"
+          onclick={reset}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="rounded bg-amber-600 px-2 py-0.5 text-[10px] text-white"
+          onclick={confirmClear}
+        >
+          Clear
+        </button>
+      </span>
+    </div>
+  {:else if mode.kind === 'confirming_delete'}
+    <div
+      class="flex items-center justify-between rounded border border-red-300 bg-red-50 px-2 py-1 text-xs text-red-800"
+    >
+      <span>Delete field <span class="font-mono">{field.name}</span>?</span>
+      <span class="flex gap-2">
+        <button
+          type="button"
+          class="rounded border border-red-300 bg-white px-2 py-0.5 text-[10px] hover:bg-red-100"
+          onclick={reset}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="rounded bg-red-600 px-2 py-0.5 text-[10px] text-white"
+          onclick={confirmDelete}
+        >
+          Delete
+        </button>
+      </span>
+    </div>
+  {:else}
+    <div class="flex flex-wrap gap-1.5 text-[11px]">
+      <button
+        type="button"
+        class="rounded border border-gray-300 px-1.5 py-0.5 hover:bg-gray-50 disabled:opacity-50"
+        onclick={startRename}
+        disabled={busy}
+      >
+        Rename
+      </button>
+      {#if field.active}
+        <button
+          type="button"
+          class="rounded border border-gray-300 px-1.5 py-0.5 hover:bg-gray-50 disabled:opacity-50"
+          onclick={deactivate}
+          disabled={busy}
+        >
+          Deactivate
+        </button>
+      {:else}
+        <button
+          type="button"
+          class="rounded border border-gray-300 px-1.5 py-0.5 hover:bg-gray-50 disabled:opacity-50"
+          onclick={activate}
+          disabled={busy}
+        >
+          Activate
+        </button>
+      {/if}
+      <button
+        type="button"
+        class="rounded border border-amber-300 px-1.5 py-0.5 text-amber-700 hover:bg-amber-50 disabled:opacity-50"
+        onclick={startConfirmClear}
+        disabled={busy}
+      >
+        Clear
+      </button>
+      <button
+        type="button"
+        class="rounded border border-red-300 px-1.5 py-0.5 text-red-700 hover:bg-red-50 disabled:opacity-50"
+        onclick={startConfirmDelete}
+        disabled={busy}
+      >
+        Delete
+      </button>
+      {#if busy}
+        <span class="text-gray-500">Working…</span>
+      {/if}
+    </div>
+  {/if}
+
+  {#if mode.kind === 'error'}
+    <p class="text-[11px] text-red-700">
+      {#if mode.code === 'entity_not_found'}
+        This field no longer exists — reload.
+      {:else}
+        {mode.status} · {mode.code} — {mode.message}
+      {/if}
+    </p>
+  {/if}
+</div>

--- a/src/js/web/src/lib/AssetTypeFieldCreateForm.svelte
+++ b/src/js/web/src/lib/AssetTypeFieldCreateForm.svelte
@@ -1,0 +1,255 @@
+<script lang="ts">
+  import { createApiClient, ProblemDetailsError } from './api'
+  import { postSchemaCommand } from './commands'
+  import type { FieldDataType, TypeView } from './schema'
+
+  interface Props {
+    /** Active asset types — used to populate the parent dropdown. */
+    parents: TypeView[]
+    onCreated: () => void
+  }
+
+  let { parents, onCreated }: Props = $props()
+
+  type SubmitState =
+    | { kind: 'idle' }
+    | { kind: 'submitting' }
+    | { kind: 'error'; status: number; code: string; message: string }
+
+  const DATA_TYPES: FieldDataType[] = [
+    'text',
+    'number',
+    'integer',
+    'boolean',
+    'date',
+    'datetime',
+  ]
+
+  let expanded = $state(false)
+  let parentId = $state('')
+  let name = $state('')
+  let dataType = $state<FieldDataType>('text')
+  let validationJson = $state('')
+  let submitState = $state<SubmitState>({ kind: 'idle' })
+  let parentInput = $state<HTMLSelectElement | null>(null)
+
+  function open(): void {
+    expanded = true
+    parentId = parents[0]?.id ?? ''
+    name = ''
+    dataType = 'text'
+    validationJson = ''
+    submitState = { kind: 'idle' }
+    queueMicrotask(() => parentInput?.focus())
+  }
+
+  function close(): void {
+    expanded = false
+    parentId = ''
+    name = ''
+    dataType = 'text'
+    validationJson = ''
+    submitState = { kind: 'idle' }
+  }
+
+  function parseValidation():
+    | { ok: true; value: Record<string, unknown> | null }
+    | { ok: false; reason: string } {
+    const trimmed = validationJson.trim()
+    if (trimmed === '') return { ok: true, value: null }
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      if (
+        parsed === null ||
+        (typeof parsed === 'object' && !Array.isArray(parsed))
+      ) {
+        return { ok: true, value: parsed as Record<string, unknown> | null }
+      }
+      return { ok: false, reason: 'Validation must be a JSON object or null' }
+    } catch (e) {
+      return { ok: false, reason: `Invalid JSON: ${String(e)}` }
+    }
+  }
+
+  async function submit(event: SubmitEvent): Promise<void> {
+    event.preventDefault()
+    if (parentId === '' || name.trim() === '') return
+    const validation = parseValidation()
+    if (!validation.ok) {
+      submitState = {
+        kind: 'error',
+        status: 0,
+        code: 'invalid_payload_shape',
+        message: validation.reason,
+      }
+      return
+    }
+    submitState = { kind: 'submitting' }
+    try {
+      await postSchemaCommand(createApiClient(), {
+        type: 'create_asset_type_field',
+        entity_id: crypto.randomUUID(),
+        payload: {
+          parent_id: parentId,
+          name: name.trim(),
+          data_type: dataType,
+          validation: validation.value,
+        },
+      })
+      close()
+      onCreated()
+    } catch (e) {
+      if (e instanceof ProblemDetailsError) {
+        submitState = {
+          kind: 'error',
+          status: e.status,
+          code: e.code,
+          message: e.message,
+        }
+      } else {
+        submitState = {
+          kind: 'error',
+          status: 0,
+          code: 'network_error',
+          message: String(e),
+        }
+      }
+    }
+  }
+
+  let nameError = $derived(
+    submitState.kind === 'error' && submitState.code === 'name_reserved',
+  )
+  let parentError = $derived(
+    submitState.kind === 'error' &&
+      submitState.code === 'parent_type_not_found',
+  )
+  let validationError = $derived(
+    submitState.kind === 'error' &&
+      submitState.code === 'invalid_payload_shape',
+  )
+  let busy = $derived(submitState.kind === 'submitting')
+  let noParents = $derived(parents.length === 0)
+</script>
+
+{#if !expanded}
+  <button
+    type="button"
+    class="w-full rounded border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+    onclick={open}
+    disabled={noParents}
+    title={noParents ? 'Create an asset type first' : ''}
+  >
+    + New asset-type field
+  </button>
+{:else}
+  <form
+    class="space-y-3 rounded border border-gray-300 p-4"
+    onsubmit={submit}
+  >
+    <div>
+      <label
+        for="new-asset-type-field-parent"
+        class="block text-xs font-medium text-gray-700"
+      >
+        Parent asset type
+      </label>
+      <select
+        id="new-asset-type-field-parent"
+        class="mt-1 w-full rounded border px-2 py-1 font-mono text-sm"
+        class:border-gray-300={!parentError}
+        class:border-red-500={parentError}
+        class:ring-1={parentError}
+        class:ring-red-500={parentError}
+        bind:value={parentId}
+        bind:this={parentInput}
+        disabled={busy}
+        required
+      >
+        {#each parents as parent (parent.id)}
+          <option value={parent.id}>{parent.name}</option>
+        {/each}
+      </select>
+    </div>
+    <div>
+      <label
+        for="new-asset-type-field-name"
+        class="block text-xs font-medium text-gray-700"
+      >
+        Name
+      </label>
+      <input
+        id="new-asset-type-field-name"
+        type="text"
+        class="mt-1 w-full rounded border px-2 py-1 font-mono text-sm"
+        class:border-gray-300={!nameError}
+        class:border-red-500={nameError}
+        class:ring-1={nameError}
+        class:ring-red-500={nameError}
+        bind:value={name}
+        disabled={busy}
+        required
+      />
+    </div>
+    <div>
+      <label
+        for="new-asset-type-field-data-type"
+        class="block text-xs font-medium text-gray-700"
+      >
+        Data type
+      </label>
+      <select
+        id="new-asset-type-field-data-type"
+        class="mt-1 w-full rounded border border-gray-300 px-2 py-1 font-mono text-sm"
+        bind:value={dataType}
+        disabled={busy}
+      >
+        {#each DATA_TYPES as dt (dt)}
+          <option value={dt}>{dt}</option>
+        {/each}
+      </select>
+    </div>
+    <div>
+      <label
+        for="new-asset-type-field-validation"
+        class="block text-xs font-medium text-gray-700"
+      >
+        Validation (JSON object, optional)
+      </label>
+      <textarea
+        id="new-asset-type-field-validation"
+        class="mt-1 w-full rounded border px-2 py-1 font-mono text-xs"
+        class:border-gray-300={!validationError}
+        class:border-red-500={validationError}
+        class:ring-1={validationError}
+        class:ring-red-500={validationError}
+        rows="2"
+        placeholder={'e.g. {"min": 0, "max": 100}'}
+        bind:value={validationJson}
+        disabled={busy}
+      ></textarea>
+    </div>
+    {#if submitState.kind === 'error'}
+      <p class="text-xs text-red-700">
+        {submitState.status} · {submitState.code} — {submitState.message}
+      </p>
+    {/if}
+    <div class="flex justify-end gap-2">
+      <button
+        type="button"
+        class="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-50"
+        onclick={close}
+        disabled={busy}
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        class="rounded bg-blue-600 px-3 py-1 text-sm text-white disabled:opacity-50"
+        disabled={busy || parentId === '' || name.trim() === ''}
+      >
+        {busy ? 'Creating…' : 'Create'}
+      </button>
+    </div>
+  </form>
+{/if}

--- a/src/js/web/src/lib/SchemaBrowser.svelte
+++ b/src/js/web/src/lib/SchemaBrowser.svelte
@@ -3,6 +3,8 @@
   import { fetchSchema, type SchemaSnapshot, type TypeView } from './schema'
   import AssetTypeActions from './AssetTypeActions.svelte'
   import AssetTypeCreateForm from './AssetTypeCreateForm.svelte'
+  import AssetTypeFieldActions from './AssetTypeFieldActions.svelte'
+  import AssetTypeFieldCreateForm from './AssetTypeFieldCreateForm.svelte'
   import TypeCard from './TypeCard.svelte'
 
   interface Props {
@@ -92,10 +94,15 @@
     </div>
   {:else if loadState.kind === 'loaded'}
     {@const assetTypes = visibleTypes(loadState.snapshot.asset_types)}
+    {@const activeAssetTypes = loadState.snapshot.asset_types.filter((t) => t.active)}
     {@const recordTypes = visibleTypes(loadState.snapshot.maintenance_record_types)}
     <div class="grid gap-8 md:grid-cols-2">
-      <div>
+      <div class="space-y-4">
         <AssetTypeCreateForm onCreated={() => void load()} />
+        <AssetTypeFieldCreateForm
+          parents={activeAssetTypes}
+          onCreated={() => void load()}
+        />
         <h3 class="mb-3 mt-4 text-sm font-semibold uppercase tracking-wide text-gray-600">
           Asset types ({assetTypes.length})
         </h3>
@@ -107,7 +114,11 @@
           <div class="space-y-3">
             {#each assetTypes as type (type.id)}
               <div>
-                <TypeCard {type} {showTombstoned} />
+                <TypeCard {type} {showTombstoned}>
+                  {#snippet fieldActions(field)}
+                    <AssetTypeFieldActions {field} onChanged={() => void load()} />
+                  {/snippet}
+                </TypeCard>
                 <AssetTypeActions {type} onChanged={() => void load()} />
               </div>
             {/each}

--- a/src/js/web/src/lib/TypeCard.svelte
+++ b/src/js/web/src/lib/TypeCard.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
-  import type { TypeView } from './schema'
+  import type { Snippet } from 'svelte'
+  import type { FieldView, TypeView } from './schema'
 
   interface Props {
     type: TypeView
     showTombstoned: boolean
+    /**
+     * Optional per-field actions row, rendered under each field's
+     * display row. Lets the asset-types column inject field lifecycle
+     * controls without modifying the type-level display.
+     */
+    fieldActions?: Snippet<[FieldView]>
   }
 
-  let { type, showTombstoned }: Props = $props()
+  let { type, showTombstoned, fieldActions }: Props = $props()
 
   let visibleFields = $derived(
     showTombstoned ? type.fields : type.fields.filter((f) => f.active),
@@ -39,23 +46,25 @@
   {:else}
     <ul class="divide-y divide-gray-100">
       {#each visibleFields as field (field.id)}
-        <li
-          class="flex items-center justify-between py-1.5 text-sm"
-          class:opacity-60={!field.active}
-        >
-          <span class="font-mono">{field.name}</span>
-          <span class="flex items-center gap-2">
-            <span class="text-xs uppercase tracking-wide text-gray-500">
-              {field.data_type}
-            </span>
-            {#if !field.active}
-              <span
-                class="rounded bg-gray-200 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-gray-700"
-              >
-                tombstoned
+        <li class="py-1.5" class:opacity-60={!field.active}>
+          <div class="flex items-center justify-between text-sm">
+            <span class="font-mono">{field.name}</span>
+            <span class="flex items-center gap-2">
+              <span class="text-xs uppercase tracking-wide text-gray-500">
+                {field.data_type}
               </span>
-            {/if}
-          </span>
+              {#if !field.active}
+                <span
+                  class="rounded bg-gray-200 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-gray-700"
+                >
+                  tombstoned
+                </span>
+              {/if}
+            </span>
+          </div>
+          {#if fieldActions}
+            {@render fieldActions(field)}
+          {/if}
         </li>
       {/each}
     </ul>

--- a/src/js/web/src/lib/commands.ts
+++ b/src/js/web/src/lib/commands.ts
@@ -1,18 +1,20 @@
 /**
- * Typed wire-format for ``POST /schema`` — asset-type lifecycle slice
- * (M4.3). Mirrors :class:`novamoc.domain.schema._payloads.SchemaRequest`
- * for the five ``*_asset_type`` commands. Field-level and
- * maintenance-record-side commands are added by M4.4 / M4.5.
+ * Typed wire-format for ``POST /schema`` — asset-type and asset-type-field
+ * lifecycle slices (M4.3 + M4.4). Mirrors
+ * :class:`novamoc.domain.schema._payloads.SchemaRequest` for the eleven
+ * ``*_asset_type`` and ``*_asset_type_field`` commands.
+ * Maintenance-record-side commands land in M4.5.
  *
  * Each body has the msgspec discriminator ``type`` (snake-case), an
  * ``entity_id`` UUID (client-generated for create; from the snapshot for
- * the other four), and a ``payload`` whose shape depends on the verb.
- * Empty-payload commands (activate / deactivate / delete) accept an
- * absent payload key; we send ``{}`` explicitly to keep the wire bytes
+ * the other verbs), and a ``payload`` whose shape depends on the verb.
+ * Empty-payload commands (activate / deactivate / clear / delete) accept
+ * an absent payload key; we send ``{}`` explicitly to keep the wire bytes
  * stable.
  */
 
 import type { ApiClient } from './api'
+import type { FieldDataType } from './schema'
 
 export interface CreateAssetTypeBody {
   type: 'create_asset_type'
@@ -44,12 +46,63 @@ export interface DeleteAssetTypeBody {
   payload: Record<string, never>
 }
 
+export interface CreateAssetTypeFieldBody {
+  type: 'create_asset_type_field'
+  entity_id: string
+  payload: {
+    parent_id: string
+    name: string
+    data_type: FieldDataType
+    validation?: Record<string, unknown> | null
+  }
+}
+
+export interface ActivateAssetTypeFieldBody {
+  type: 'activate_asset_type_field'
+  entity_id: string
+  payload: Record<string, never>
+}
+
+export interface UpdateAssetTypeFieldBody {
+  type: 'update_asset_type_field'
+  entity_id: string
+  payload: {
+    name?: string
+    data_type?: FieldDataType
+    validation?: Record<string, unknown> | null
+  }
+}
+
+export interface DeactivateAssetTypeFieldBody {
+  type: 'deactivate_asset_type_field'
+  entity_id: string
+  payload: Record<string, never>
+}
+
+export interface ClearAssetTypeFieldBody {
+  type: 'clear_asset_type_field'
+  entity_id: string
+  payload: Record<string, never>
+}
+
+export interface DeleteAssetTypeFieldBody {
+  type: 'delete_asset_type_field'
+  entity_id: string
+  payload: Record<string, never>
+}
+
 export type SchemaCommandBody =
   | CreateAssetTypeBody
   | ActivateAssetTypeBody
   | UpdateAssetTypeBody
   | DeactivateAssetTypeBody
   | DeleteAssetTypeBody
+  | CreateAssetTypeFieldBody
+  | ActivateAssetTypeFieldBody
+  | UpdateAssetTypeFieldBody
+  | DeactivateAssetTypeFieldBody
+  | ClearAssetTypeFieldBody
+  | DeleteAssetTypeFieldBody
 
 export type Outcome =
   | 'created'

--- a/src/js/web/tests/e2e/field-lifecycle.spec.ts
+++ b/src/js/web/tests/e2e/field-lifecycle.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Full-lifecycle browser e2e for an ``asset_type_field`` through the
+ * M4.4 schema browser UI. Drives every accepted verb — create,
+ * rename, deactivate, activate (resurrection), clear, delete — plus a
+ * duplicate-name attempt to exercise the inline ``name_reserved``
+ * rendering path on the field-level form.
+ *
+ * The asset-type lifecycle spec runs first under the same in-memory
+ * server and leaves zero asset types, but the ``schema_version``
+ * counter persists across specs (it tracks ``MAX(seq)`` on
+ * ``schema_change_log``, not the current state). This spec therefore
+ * does NOT assert absolute version numbers — it relies on positive
+ * existence assertions plus the schema browser's reload-on-change
+ * pattern.
+ *
+ * Field-level and type-level action rows share button labels
+ * (Rename / Activate / Deactivate / Delete). Field-level actions live
+ * inside the field's ``<li>`` element so this spec scopes those
+ * selectors through ``page.getByRole('listitem')``; type-level
+ * actions hang off the type's ``<article>`` sibling and use the
+ * unscoped ``page`` root.
+ */
+
+import { expect, test, type Locator } from '@playwright/test'
+
+const PARENT = 'field-host'
+const FIELD = 'serial_number'
+const FIELD_RENAMED = `${FIELD}_v2`
+
+test('asset_type_field lifecycle through the schema browser UI', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: 'novaMOC' })).toBeVisible()
+
+  // -- Seed: create the parent asset type so the field form's
+  //    parent dropdown has at least one option.
+  await page.getByRole('button', { name: '+ New asset type' }).click()
+  await page.getByRole('textbox', { name: 'Name' }).fill(PARENT)
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await expect(page.getByRole('heading', { name: PARENT })).toBeVisible()
+
+  // -- create field
+  await page.getByRole('button', { name: '+ New asset-type field' }).click()
+  await expect(
+    page.getByRole('combobox', { name: 'Parent asset type' }),
+  ).toHaveValue(/.+/)
+  await page.getByRole('textbox', { name: 'Name' }).fill(FIELD)
+  await page.getByRole('combobox', { name: 'Data type' }).selectOption('text')
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+
+  // The field appears as a list item under the parent's card; capture it
+  // and use it to scope field-level button selectors that share their
+  // accessible name with type-level buttons.
+  const fieldRow: Locator = page
+    .getByRole('listitem')
+    .filter({ hasText: FIELD })
+  await expect(fieldRow).toBeVisible()
+  await expect(fieldRow.getByText('text', { exact: true })).toBeVisible()
+
+  // -- duplicate field name → inline name_reserved
+  await page.getByRole('button', { name: '+ New asset-type field' }).click()
+  await page.getByRole('textbox', { name: 'Name' }).fill(FIELD)
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await expect(page.getByText(/409 · name_reserved/)).toBeVisible()
+  await page.getByRole('button', { name: 'Cancel' }).click()
+
+  // -- rename field
+  await fieldRow.getByRole('button', { name: 'Rename' }).click()
+  await expect(fieldRow.getByRole('button', { name: 'Save' })).toBeDisabled()
+  await fieldRow.getByRole('textbox', { name: 'New name' }).fill(FIELD_RENAMED)
+  await fieldRow.getByRole('button', { name: 'Save' }).click()
+  const renamedRow: Locator = page
+    .getByRole('listitem')
+    .filter({ hasText: FIELD_RENAMED })
+  await expect(renamedRow).toBeVisible()
+
+  // -- deactivate field (drops from the active list)
+  await renamedRow.getByRole('button', { name: 'Deactivate' }).click()
+  await expect(
+    page.getByRole('listitem').filter({ hasText: FIELD_RENAMED }),
+  ).toHaveCount(0)
+
+  // -- show tombstoned → field reappears with Activate button
+  await page.getByRole('checkbox', { name: 'Show tombstoned' }).check()
+  const tombstonedRow: Locator = page
+    .getByRole('listitem')
+    .filter({ hasText: FIELD_RENAMED })
+  await expect(tombstonedRow).toBeVisible()
+  await expect(tombstonedRow.getByRole('button', { name: 'Activate' })).toBeVisible()
+
+  // -- activate (resurrection)
+  await tombstonedRow.getByRole('button', { name: 'Activate' }).click()
+  await expect(tombstonedRow.getByRole('button', { name: 'Deactivate' })).toBeVisible()
+
+  // -- clear (one-step confirm)
+  await tombstonedRow.getByRole('button', { name: 'Clear' }).click()
+  await expect(
+    page.getByText(`Clear values for ${FIELD_RENAMED}?`),
+  ).toBeVisible()
+  await tombstonedRow.getByRole('button', { name: 'Clear', exact: true }).click()
+  // After clear, the field is still present (clear wipes values, not the
+  // definition). The action buttons return.
+  await expect(tombstonedRow.getByRole('button', { name: 'Rename' })).toBeVisible()
+
+  // -- delete field (two-step confirm)
+  await tombstonedRow.getByRole('button', { name: 'Delete' }).click()
+  await expect(page.getByText(`Delete field ${FIELD_RENAMED}?`)).toBeVisible()
+  await tombstonedRow.getByRole('button', { name: 'Delete' }).click()
+  await expect(
+    page.getByRole('listitem').filter({ hasText: FIELD_RENAMED }),
+  ).toHaveCount(0)
+
+  // -- teardown: delete the parent asset type (two-step confirm on the
+  //    type-level action row).
+  await page.getByRole('checkbox', { name: 'Show tombstoned' }).uncheck()
+  await page.getByRole('button', { name: 'Delete' }).click()
+  await expect(page.getByText(`Delete ${PARENT}?`)).toBeVisible()
+  await page.getByRole('button', { name: 'Delete' }).click()
+  await expect(page.getByRole('heading', { name: PARENT })).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

- Extends ``commands.ts`` with the six typed ``*_asset_type_field`` POST /schema command bodies.
- Adds ``AssetTypeFieldCreateForm`` — collapsible ``+ New asset-type field`` form. ``parent_id`` is sourced from a dropdown populated with the active asset types (per the M4.4 issue). Validation accepts an optional JSON object. Inline ``name_reserved`` / ``parent_type_not_found`` / ``invalid_payload_shape`` rendering.
- Adds ``AssetTypeFieldActions`` — per-field action row with inline rename (``update_*``), one-click activate / deactivate, one-step clear confirm (amber, distinct from delete), and two-step delete confirm. ``entity_not_found`` renders as a "reload" hint.
- Refactors ``TypeCard`` to accept an optional ``fieldActions`` snippet so per-field controls plug in without modifying the type-level display. M4.5 maintenance-record-type fields will reuse the same hook.
- Wires both new components into ``SchemaBrowser`` on the asset-types column.
- Adds ``tests/e2e/field-lifecycle.spec.ts`` — full-lifecycle Playwright walk (create / rename / deactivate / activate / clear / delete + duplicate-name conflict). Field- and type-level selectors are scoped through ``page.getByRole('listitem').filter(...)`` since they share button labels.

Maintenance-record-side lifecycle deferred to #45.

## Test plan
- [x] ``npm run check`` clean (95 files, 0 errors, 0 warnings)
- [x] ``npm run build`` clean
- [x] ``npm run test:e2e`` — both ``asset-type-lifecycle`` and ``field-lifecycle`` specs green
- [x] ``just check`` clean (308 tests pass, ratchet unchanged at 22 violations)

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)