### PR TITLE
M5.5: PasswordHasher (argon2-cffi)

### DIFF
--- a/src/py/novamoc/domain/accounts/_password.py
+++ b/src/py/novamoc/domain/accounts/_password.py
@@ -19,6 +19,12 @@ from dataclasses import dataclass
 import argon2
 import argon2.exceptions
 
+# ``InvalidHashError`` is a ``ValueError`` rather than an ``Argon2Error``,
+# so both bases must be listed to fold every verify failure into ``False``.
+# Named so the ``except`` clause stays unambiguously a tuple of exception
+# types under both ``except A, B:`` and ``except (A, B):`` parser forms.
+_VERIFY_ERRORS = (argon2.exceptions.Argon2Error, argon2.exceptions.InvalidHashError)
+
 
 @dataclass(frozen=True, slots=True)
 class PasswordHasher:
@@ -81,7 +87,7 @@ class PasswordHasher:
         """
         try:
             return self._inner().verify(encoded, password)
-        except (argon2.exceptions.Argon2Error, argon2.exceptions.InvalidHashError):
+        except _VERIFY_ERRORS:
             return False
 
     def check_needs_rehash(self, encoded: str) -> bool:

--- a/src/py/novamoc/domain/accounts/_password.py
+++ b/src/py/novamoc/domain/accounts/_password.py
@@ -1,0 +1,104 @@
+"""PasswordHasher wrapper over argon2-cffi (ADR-020, M5.5).
+
+Wraps :class:`argon2.PasswordHasher` to fold the library's exception hierarchy
+into a boolean return for :meth:`verify` and :meth:`check_needs_rehash`, so
+callers never branch on ``VerifyMismatchError`` vs ``InvalidHashError``.  Cost
+parameters live on the dataclass so settings-driven tuning is a constructor
+call, not module-global state.
+
+Inner :class:`argon2.PasswordHasher` instances are built lazily on each
+call — the underlying object is cheap to construct (parameter validation only,
+no I/O) and a frozen dataclass cannot hold a mutable private attribute without
+``object.__setattr__``.  Lazy construction keeps the class simple.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import argon2
+import argon2.exceptions
+
+
+@dataclass(frozen=True, slots=True)
+class PasswordHasher:
+    """Thin wrapper over argon2-cffi with OWASP-recommended defaults.
+
+    Defaults align with OWASP / RFC 9106 for argon2id as of 2026:
+    m=64 MiB, t=3 iterations, p=4 lanes.  The login handler (M5.10) calls
+    :meth:`check_needs_rehash` after every successful verify so active users
+    upgrade automatically when cost parameters rotate.
+
+    Args:
+        time_cost: Number of iterations (RFC 9106 ``t``).
+        memory_cost_kib: Memory in KiB (RFC 9106 ``m``); maps 1:1 to
+            ``argon2.PasswordHasher(memory_cost=...)``.
+        parallelism: Degree of parallelism (RFC 9106 ``p``).
+    """
+
+    time_cost: int = 3
+    memory_cost_kib: int = 64 * 1024  # 64 MiB
+    parallelism: int = 4
+
+    @classmethod
+    def from_defaults(cls) -> PasswordHasher:
+        """Return an instance with OWASP-recommended defaults."""
+        return cls()
+
+    def _inner(self) -> argon2.PasswordHasher:
+        return argon2.PasswordHasher(
+            time_cost=self.time_cost,
+            memory_cost=self.memory_cost_kib,
+            parallelism=self.parallelism,
+        )
+
+    def hash(self, password: str) -> str:
+        """Return an argon2id-encoded hash of *password*.
+
+        Args:
+            password: Plaintext password to hash.
+
+        Returns:
+            An encoded ``$argon2id$...`` string including the salt and
+            cost parameters.
+        """
+        return self._inner().hash(password)
+
+    def verify(self, encoded: str, password: str) -> bool:
+        """Verify *password* against an argon2id-encoded hash.
+
+        Never raises; all argon2-cffi exception types are folded into
+        ``False`` so callers do not branch on
+        ``VerifyMismatchError`` vs ``InvalidHashError``.
+
+        Args:
+            encoded: The ``$argon2id$...`` string produced by :meth:`hash`.
+            password: Plaintext password to check.
+
+        Returns:
+            ``True`` iff the password matches; ``False`` for any mismatch
+            or malformed encoded string.
+        """
+        try:
+            return self._inner().verify(encoded, password)
+        except argon2.exceptions.Argon2Error, argon2.exceptions.InvalidHashError:
+            return False
+
+    def check_needs_rehash(self, encoded: str) -> bool:
+        """Return whether *encoded* should be rehashed with current parameters.
+
+        Malformed encoded strings are treated as needing rehash — the caller
+        should hash the plaintext again under the current parameters rather
+        than attempting to use an unparseable stored value.
+
+        Args:
+            encoded: The ``$argon2id$...`` string to inspect.
+
+        Returns:
+            ``True`` if the hash's embedded parameters differ from this
+            instance's parameters, or if *encoded* is malformed.
+        """
+        try:
+            return self._inner().check_needs_rehash(encoded)
+        except argon2.exceptions.InvalidHashError:
+            return True

--- a/src/py/novamoc/domain/accounts/_password.py
+++ b/src/py/novamoc/domain/accounts/_password.py
@@ -81,7 +81,7 @@ class PasswordHasher:
         """
         try:
             return self._inner().verify(encoded, password)
-        except argon2.exceptions.Argon2Error, argon2.exceptions.InvalidHashError:
+        except (argon2.exceptions.Argon2Error, argon2.exceptions.InvalidHashError):
             return False
 
     def check_needs_rehash(self, encoded: str) -> bool:

--- a/tests/accounts/test_password.py
+++ b/tests/accounts/test_password.py
@@ -1,0 +1,53 @@
+"""Tests for PasswordHasher (M5.5, issue #87).
+
+Argon2id at defaults takes ~100-300 ms per hash, which makes five full-cost
+round-trips unacceptably slow for a unit test suite. All tests here use a
+deliberately weakened hasher (``time_cost=1, memory_cost_kib=8192,
+parallelism=1``) to keep the suite under 2 s. The production defaults remain
+on the class (``time_cost=3, memory_cost_kib=65536, parallelism=4``) per OWASP
+/ RFC 9106; only the test-local instances are tuned down.
+"""
+
+# hardcoded test password literals
+
+from __future__ import annotations
+
+from novamoc.domain.accounts._password import PasswordHasher
+
+_FAST = PasswordHasher(time_cost=1, memory_cost_kib=8192, parallelism=1)
+
+
+def test_hash_then_verify_round_trip_succeeds() -> None:
+    encoded = _FAST.hash("correct-horse-battery-staple")
+
+    assert _FAST.verify(encoded, "correct-horse-battery-staple") is True
+
+
+def test_verify_wrong_password_returns_false_no_exception() -> None:
+    encoded = _FAST.hash("correct-horse-battery-staple")
+
+    assert _FAST.verify(encoded, "wrong-password") is False
+
+
+def test_two_hashes_of_same_password_differ() -> None:
+    first = _FAST.hash("hunter2")
+    second = _FAST.hash("hunter2")
+
+    assert first != second
+
+
+def test_check_needs_rehash_after_cost_bump() -> None:
+    low_cost = PasswordHasher(time_cost=1, memory_cost_kib=8192, parallelism=1)
+    encoded = low_cost.hash("hunter2")
+
+    higher_cost = PasswordHasher(time_cost=2, memory_cost_kib=8192, parallelism=1)
+
+    assert higher_cost.check_needs_rehash(encoded) is True
+
+
+def test_verify_malformed_encoded_returns_false_no_exception() -> None:
+    assert _FAST.verify("not-a-hash", "hunter2") is False
+
+
+def test_check_needs_rehash_malformed_returns_true_no_exception() -> None:
+    assert _FAST.check_needs_rehash("not-a-hash") is True


### PR DESCRIPTION
## Summary

- Adds `src/py/novamoc/domain/accounts/_password.py`: a frozen dataclass wrapping `argon2.PasswordHasher` that folds all argon2-cffi exception types into a boolean return for `verify` (never raises), and treats malformed hashes as needing rehash in `check_needs_rehash`.
- Cost parameters (`time_cost`, `memory_cost_kib`, `parallelism`) are constructor args with OWASP/RFC 9106 defaults (m=64 MiB, t=3, p=4) so settings-driven tuning is a constructor call, not module-global state.
- Inner `argon2.PasswordHasher` is built lazily per call — cheap to construct, avoids `object.__setattr__` on a frozen dataclass.

Closes #87.

## Test plan

- [x] `uv run pytest tests/accounts/test_password.py -v` — 6/6 pass
- [x] `uv run ruff check src/py/novamoc/domain/accounts/_password.py tests/accounts/test_password.py` — clean
- [x] `uv run ty check src/py/novamoc/domain/accounts/_password.py` — 0 diagnostics
- [x] `just ratchet` — `Ratchet OK: 22 violations, baseline matches` (no new violations)
- [x] Hash-then-verify round-trip succeeds
- [x] Wrong password returns `False`, no exception
- [x] Two hashes of the same password differ (distinct salts)
- [x] `check_needs_rehash` returns `True` after cost-parameter bump on verifier
- [x] `verify` against malformed encoded string returns `False`, no exception
- [x] `check_needs_rehash` against malformed encoded string returns `True`, no exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)