### PR TITLE
M5.3: User model + UserService with case-folded usernames

### DIFF
--- a/src/py/novamoc/db/models/_auth/__init__.py
+++ b/src/py/novamoc/db/models/_auth/__init__.py
@@ -7,5 +7,6 @@ themselves tenant-scoped. The storage-layer listeners in
 """
 
 from ._tenant import Tenant
+from ._user import User
 
-__all__ = ("Tenant",)
+__all__ = ("Tenant", "User")

--- a/src/py/novamoc/db/models/_auth/_user.py
+++ b/src/py/novamoc/db/models/_auth/_user.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from advanced_alchemy.base import UUIDAuditBase
+from advanced_alchemy.types import DateTimeUTC
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class User(UUIDAuditBase):
+    """User account identity (ADR-020).
+
+    PK is the inherited UUIDv7 from :class:`UUIDAuditBase`; ``username``
+    is mutable (rename support) — the stable identity is the surrogate
+    UUID, not the login string.
+
+    Not tenant-scoped — a user account is a global identity that links
+    to one (eventually many) tenants via ``user_tenant_memberships``.
+    Storage listeners short-circuit naturally because the table has no
+    ``tenant_id`` column.
+
+    ``username`` is stored case-folded (NFKC + ``casefold()``) by the
+    service layer; never write raw user input directly to this column.
+
+    ``disabled_at`` is a timestamp rather than a boolean — the moment of
+    disable is recoverable without a separate audit row, and login fails
+    closed when set (anti-enumeration 401, ADR-020).
+    """
+
+    __tablename__ = "users"
+
+    username: Mapped[str] = mapped_column(unique=True)
+    password_hash: Mapped[str]
+    disabled_at: Mapped[datetime | None] = mapped_column(DateTimeUTC, default=None)

--- a/src/py/novamoc/domain/accounts/_services.py
+++ b/src/py/novamoc/domain/accounts/_services.py
@@ -5,9 +5,26 @@ tenant-scoped, so callers do not pass a ``tenant_id`` and the storage
 listeners short-circuit on column absence.
 """
 
+from __future__ import annotations
+
+import unicodedata
+from typing import TYPE_CHECKING, Any
+
 from advanced_alchemy.extensions.litestar import repository, service
 
-from novamoc.db.models._auth import Tenant
+from novamoc.db.models._auth import Tenant, User
+
+if TYPE_CHECKING:
+    from advanced_alchemy.service import ModelDictT
+
+
+def _fold_username(value: str) -> str:
+    """NFKC-normalise and casefold a username.
+
+    Ensures ``Admin`` and ``admin`` resolve to the same row
+    (anti-impersonation, ADR-020).
+    """
+    return unicodedata.normalize("NFKC", value).casefold()
 
 
 class TenantService(service.SQLAlchemyAsyncRepositoryService[Tenant]):
@@ -15,3 +32,30 @@ class TenantService(service.SQLAlchemyAsyncRepositoryService[Tenant]):
         model_type = Tenant
 
     repository_type = Repo
+
+
+class UserService(service.SQLAlchemyAsyncRepositoryService[User]):
+    """Service for the global user-account registry (ADR-020).
+
+    Applies NFKC + ``casefold()`` to ``username`` at write time so
+    ``Admin`` and ``admin`` always resolve to the same row.
+    """
+
+    class Repo(repository.SQLAlchemyAsyncRepository[User]):
+        model_type = User
+
+    repository_type = Repo
+
+    async def create(self, data: ModelDictT[User] | User, **kwargs: Any) -> User:
+        """Create a user, folding ``username`` before persisting."""
+        if isinstance(data, dict):
+            d: dict[str, Any] = data  # type: ignore  # ty can't narrow ModelDictT through isinstance
+            raw = d.get("username")
+            if isinstance(raw, str):
+                data = {**d, "username": _fold_username(raw)}
+        return await super().create(data, **kwargs)
+
+    async def get_by_username(self, username: str) -> User | None:
+        """Return the user whose folded username matches, or ``None``."""
+        folded = _fold_username(username)
+        return await self.get_one_or_none(username=folded)

--- a/tests/accounts/test_user_model.py
+++ b/tests/accounts/test_user_model.py
@@ -1,0 +1,91 @@
+"""Smoke tests for the User model and UserService (ADR-020, M5.3).
+
+The table is not tenant-scoped — these tests opt out of the autouse
+``tenant`` fixture so the contextvar isn't set, mirroring how login
+and membership tests will be wired.
+"""
+# ruff: noqa: RUF001  # fullwidth chars are intentional test data for NFKC-fold coverage
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from novamoc.db.models import _auth as auth_models
+from novamoc.domain.accounts._services import UserService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.no_tenant
+async def test_user_id_is_assigned_uuid_after_flush(session: AsyncSession) -> None:
+    obj = auth_models.User(
+        username="alice",
+        password_hash="$argon2id$v=19$m=65536,t=3,p=4$hash",  # noqa: S106
+    )
+    session.add(obj)
+    await session.flush()
+    assert isinstance(obj.id, UUID)
+    assert obj.username == "alice"
+    assert obj.disabled_at is None
+
+
+@pytest.mark.no_tenant
+async def test_user_unique_username_constraint_raises(session: AsyncSession) -> None:
+    obj1 = auth_models.User(username="bob", password_hash="hash1")  # noqa: S106
+    obj2 = auth_models.User(username="bob", password_hash="hash2")  # noqa: S106
+    session.add(obj1)
+    session.add(obj2)
+    with pytest.raises(IntegrityError):
+        await session.flush()
+
+
+@pytest.mark.no_tenant
+async def test_user_service_create_folds_username(session: AsyncSession) -> None:
+    svc = UserService(session=session)
+    obj = await svc.create(
+        data={"username": "Alice", "password_hash": "hash"},
+        auto_commit=False,
+    )
+    await session.flush()
+    assert obj.username == "alice"
+
+
+@pytest.mark.no_tenant
+async def test_user_service_create_folds_unicode_username(
+    session: AsyncSession,
+) -> None:
+    svc = UserService(session=session)
+    obj = await svc.create(
+        data={"username": "ＡＤＭＩＮ", "password_hash": "hash"},
+        auto_commit=False,
+    )
+    await session.flush()
+    # NFKC normalises fullwidth chars to ASCII, casefold lowercases
+    assert obj.username == "admin"
+
+
+@pytest.mark.no_tenant
+async def test_get_by_username_case_insensitive(session: AsyncSession) -> None:
+    svc = UserService(session=session)
+    await svc.create(
+        data={"username": "Charlie", "password_hash": "hash"},
+        auto_commit=False,
+    )
+    await session.flush()
+    found = await svc.get_by_username("CHARLIE")
+    assert found is not None
+    assert found.username == "charlie"
+
+
+@pytest.mark.no_tenant
+async def test_get_by_username_returns_none_when_not_found(
+    session: AsyncSession,
+) -> None:
+    svc = UserService(session=session)
+    found = await svc.get_by_username("nonexistent")
+    assert found is None


### PR DESCRIPTION
## Summary

- Adds `db/models/_auth/_user.py` — the global `User` table (PK: UUIDv7, not tenant-scoped) with `username` (unique), `password_hash` (argon2id encoded string), and `disabled_at` (timestamp, ADR-020).
- Re-exports `User` from `db/models/_auth/__init__.py` alongside `Tenant`.
- Appends `_fold_username()` helper and `UserService` to `domain/accounts/_services.py`. The service overrides `create()` to NFKC-normalise + casefold `username` at write time, and adds `get_by_username()` with the same fold — so `Admin` / `admin` / `ＡＤＭＩＮ` always resolve to the same row (anti-impersonation, ADR-020).

Closes #85.

## Test plan

- [x] `uv run pytest tests/accounts/test_user_model.py` — 6/6 pass
- [x] `just ratchet` — `Ratchet OK: 22 violations, baseline matches` (no new violations)
- [x] Full suite: 429 passed, 7 pre-existing snapshot failures (identical to `main`)
- [x] `UserService(session).create({"username": "Alice", ...})` → `obj.username == "alice"`
- [x] `UserService(session).get_by_username("ALICE")` → returns same row
- [x] `UserService(session).get_by_username("ＡＤＭＩＮ")` → `obj.username == "admin"` (NFKC fold)
- [x] Duplicate `username` raises `IntegrityError` (DB-level UNIQUE constraint verified)
- [x] `disabled_at` defaults to `None` and round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)