### PR TITLE
test(snapshot): migrate remaining string tenant_id literals to UUID (M5.2 follow-up)

### DIFF
--- a/tests/snapshot/test_pagination.py
+++ b/tests/snapshot/test_pagination.py
@@ -44,6 +44,7 @@ from novamoc.domain.snapshot.services import (
     MaintenanceRecordFieldValueService,
     MaintenanceRecordService,
 )
+from tests._constants import DEV_TENANT_ID
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -66,7 +67,7 @@ def paginator(session: AsyncSession) -> SnapshotPaginator:
 
 
 async def _make_asset_type(
-    session: AsyncSession, *, name: str = "Truck", tenant_id: str = "t1"
+    session: AsyncSession, *, name: str = "Truck", tenant_id: UUID = DEV_TENANT_ID
 ) -> AssetType:
     asset_type = AssetType(id=uuid4(), tenant_id=tenant_id, name=name, active=True)
     session.add(asset_type)
@@ -78,7 +79,7 @@ async def _make_maintenance_record_type(
     session: AsyncSession,
     *,
     name: str = "Inspection",
-    tenant_id: str = "t1",
+    tenant_id: UUID = DEV_TENANT_ID,
 ) -> MaintenanceRecordType:
     mrt = MaintenanceRecordType(id=uuid4(), tenant_id=tenant_id, name=name, active=True)
     session.add(mrt)
@@ -90,7 +91,7 @@ async def _make_asset(
     session: AsyncSession,
     *,
     type_id: UUID,
-    tenant_id: str = "t1",
+    tenant_id: UUID = DEV_TENANT_ID,
     deleted: bool = False,
     hlc: str = "0001700000000000-00000-abc",
 ) -> Asset:
@@ -111,7 +112,7 @@ async def _make_asset(
 async def _make_event(  # noqa: PLR0913  # test-helper builder: explicit keyword args > a dict literal
     session: AsyncSession,
     *,
-    tenant_id: str = "t1",
+    tenant_id: UUID = DEV_TENANT_ID,
     hlc: str,
     type_id: UUID,
     entity_id: UUID,
@@ -134,7 +135,9 @@ async def _make_event(  # noqa: PLR0913  # test-helper builder: explicit keyword
     await session.flush()
 
 
-async def _bump_schema_version(session: AsyncSession, *, tenant_id: str = "t1") -> int:
+async def _bump_schema_version(
+    session: AsyncSession, *, tenant_id: UUID = DEV_TENANT_ID
+) -> int:
     """Append a no-op schema_change_log row to bump current_version()."""
     current = await session.execute(
         select(func.coalesce(func.max(SchemaChangeLog.seq), 0)).where(
@@ -229,7 +232,7 @@ async def test_cross_table_walk(
 
     session.add(
         AssetFieldValue(
-            tenant_id="t1",
+            tenant_id=DEV_TENANT_ID,
             asset_id=asset.id,
             field_id="col:name",
             value_json="Truck-1",
@@ -238,7 +241,7 @@ async def test_cross_table_walk(
     )
     mr = MaintenanceRecord(
         id=uuid4(),
-        tenant_id="t1",
+        tenant_id=DEV_TENANT_ID,
         type_id=mr_type.id,
         asset_id=asset.id,
         name=None,
@@ -250,7 +253,7 @@ async def test_cross_table_walk(
     await session.flush()
     session.add(
         MaintenanceRecordFieldValue(
-            tenant_id="t1",
+            tenant_id=DEV_TENANT_ID,
             maintenance_record_id=mr.id,
             field_id="col:name",
             value_json="Inspection-A",
@@ -294,7 +297,7 @@ async def test_skips_empty_intermediate_tables(
     asset = await _make_asset(session, type_id=asset_type.id)
     mr = MaintenanceRecord(
         id=uuid4(),
-        tenant_id="t1",
+        tenant_id=DEV_TENANT_ID,
         type_id=mr_type.id,
         asset_id=asset.id,
         name=None,

--- a/tests/snapshot/test_snapshot_cross_tenant_isolation.py
+++ b/tests/snapshot/test_snapshot_cross_tenant_isolation.py
@@ -4,9 +4,9 @@ Regression guard for the snapshot endpoint's tenant scoping. The
 paginator carries no tenant predicate of its own — Layer 1 of
 ``db._listeners`` injects ``WHERE tenant_id = <ctx>`` on every ORM
 SELECT against the four projection tables and on the ``current_seq``
-/ ``current_version`` aggregates. Seeds equivalent rows under ``t-a``
-and ``t-b``; under each tenant context, the bulk transfer must see
-only its own data.
+/ ``current_version`` aggregates. Seeds equivalent rows under
+``DEV_TENANT_ID_A`` and ``DEV_TENANT_ID_B``; under each tenant
+context, the bulk transfer must see only its own data.
 """
 
 from __future__ import annotations
@@ -27,6 +27,7 @@ from novamoc.domain.snapshot.services import (
     MaintenanceRecordFieldValueService,
     MaintenanceRecordService,
 )
+from tests._constants import DEV_TENANT_ID_A, DEV_TENANT_ID_B
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -47,7 +48,7 @@ def _paginator(session: AsyncSession) -> SnapshotPaginator:
     )
 
 
-async def _seed_asset(session: AsyncSession, *, tenant_id: str) -> tuple[UUID, UUID]:
+async def _seed_asset(session: AsyncSession, *, tenant_id: UUID) -> tuple[UUID, UUID]:
     """Seed one asset_type + one asset under ``tenant_id``. Returns
     ``(type_id, asset_id)``."""
     type_id = uuid4()
@@ -56,6 +57,9 @@ async def _seed_asset(session: AsyncSession, *, tenant_id: str) -> tuple[UUID, U
         AssetType(id=type_id, tenant_id=tenant_id, name=f"Truck-{type_id}", active=True)
     )
     await session.flush()
+    # HLC node-id suffix needs to be distinct per tenant so the two
+    # seeded rows don't collide. Last three hex chars of the tenant
+    # UUID give "00a" / "00b" for the canonical A / B fixtures.
     session.add(
         Asset(
             id=asset_id,
@@ -64,7 +68,7 @@ async def _seed_asset(session: AsyncSession, *, tenant_id: str) -> tuple[UUID, U
             name=None,
             properties={},
             deleted=False,
-            row_state_hlc=f"0001700000000000-00000-{tenant_id}",
+            row_state_hlc=f"0001700000000000-00000-{str(tenant_id)[-3:]}",
         )
     )
     await session.flush()
@@ -95,16 +99,16 @@ async def test_paginator_isolates_tenants(session: AsyncSession) -> None:
     # Pre-seed both tenants. The asset_type rows must come first so the
     # FK on Asset(type_id, tenant_id) resolves; use ``use_tenant`` so the
     # auto-stamp listener stamps the right tenant.
-    with use_tenant("t-a"):
-        _, asset_a = await _seed_asset(session, tenant_id="t-a")
-    with use_tenant("t-b"):
-        _, asset_b = await _seed_asset(session, tenant_id="t-b")
+    with use_tenant(DEV_TENANT_ID_A):
+        _, asset_a = await _seed_asset(session, tenant_id=DEV_TENANT_ID_A)
+    with use_tenant(DEV_TENANT_ID_B):
+        _, asset_b = await _seed_asset(session, tenant_id=DEV_TENANT_ID_B)
 
     paginator = _paginator(session)
 
-    with use_tenant("t-a"):
+    with use_tenant(DEV_TENANT_ID_A):
         seen_a = await _collect_asset_ids(paginator)
-    with use_tenant("t-b"):
+    with use_tenant(DEV_TENANT_ID_B):
         seen_b = await _collect_asset_ids(paginator)
 
     assert seen_a == {asset_a}


### PR DESCRIPTION
## Summary

Two snapshot test files slipped through M5.2's ``\"t1\"`` / ``\"t-a\"`` / ``\"t-b\"`` → UUID-constant sweep (PR #103) because the M2.3 snapshot-paginator work merged after the grep had run (PR #104).

- ``tests/snapshot/test_pagination.py`` — 9 sites: defaults on 5 helper signatures plus 4 explicit call-site overrides. Failed at runtime with ``CrossTenantWriteError`` because the autouse ``tenant`` fixture sets ``current_tenant_id`` to a UUID and the row's string ``\"t1\"`` mismatched the listener's context check.
- ``tests/snapshot/test_snapshot_cross_tenant_isolation.py`` — 4 sites + 1 helper signature. ty flagged each ``use_tenant(\"t-a\")`` / ``use_tenant(\"t-b\")`` against the post-M5.2 ``use_tenant(UUID)`` signature.

Both files now import from ``tests._constants`` and use the canonical fixture UUIDs (``DEV_TENANT_ID`` / ``DEV_TENANT_ID_A`` / ``DEV_TENANT_ID_B``).

One small judgment call in ``test_snapshot_cross_tenant_isolation.py``: the seeded asset's HLC node-id suffix interpolates the tenant id (``f\"...-{tenant_id}\"``). I kept the per-tenant-distinct intent by using ``str(tenant_id)[-3:]``, which gives ``\"00a\"`` / ``\"00b\"`` for the canonical A/B fixtures and preserves the original 3-char node-id length.

No production code touched.

## Test plan

- [x] ``just check`` — green end-to-end (438 pytest + 3 playwright e2e + ratchet 22/22 matches baseline)
- [x] ``rg '\"t-?[ab1]\"' tests/ src/`` — no hits remaining
- [x] Confirmed pre-existing failures on bare ``main``: 7 snapshot test failures (6 in ``test_pagination``, 1 in ``test_snapshot_cross_tenant_isolation``); all green after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)