### PR TITLE
chore(github): add bug, feature, and tech-debt issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Report something that isn't working the way it should.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the bug.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of novaMOC does this affect?
+      options:
+        - Server (Python / Litestar)
+        - Client (Svelte SPA)
+        - Sync protocol (event log / HLC / projections)
+        - Schema / ADRs / docs
+        - Tooling (uv / ruff / ty / justfile / CI)
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that trigger the bug. Include commands, request bodies, or seed data where relevant.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead. Paste stack traces or error responses verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Anything reproducer-relevant — Python version, OS, browser, commit SHA, etc. Omit fields that don't apply.
+      placeholder: |
+        - novaMOC commit:
+        - Python:
+        - OS:
+        - Browser (for client bugs):
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, links to related issues / ADRs, anything else useful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,18 +29,11 @@ body:
     id: steps
     attributes:
       label: Steps to reproduce
-      description: Minimal steps that trigger the bug. Include commands, request bodies, or seed data where relevant.
+      description: Minimal steps that trigger the bug. Paste exact commands, request bodies, and seed data verbatim — not paraphrases — so they can be re-run as-is.
       placeholder: |
-        1. ...
-        2. ...
+        1. uv run pytest tests/...
+        2. curl -X POST ...
         3. ...
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behaviour
     validations:
       required: true
 
@@ -48,9 +41,28 @@ body:
     id: actual
     attributes:
       label: Actual behaviour
-      description: What happened instead. Paste stack traces or error responses verbatim.
+      description: What happened. Paste stack traces and error responses verbatim.
     validations:
       required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened instead. Skip this if it's obvious from the actual behaviour (e.g. a crash where the expectation is "no crash").
+    validations:
+      required: false
+
+  - type: textarea
+    id: affected_files
+    attributes:
+      label: Likely affected files
+      description: Best-guess pointer to the files or modules involved. Saves the assignee from grepping cold. Leave blank if unsure.
+      placeholder: |
+        - src/py/novamoc/...
+        - tests/...
+    validations:
+      required: false
 
   - type: textarea
     id: environment
@@ -68,7 +80,7 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: Additional context
-      description: Logs, screenshots, links to related issues / ADRs, anything else useful.
+      label: Related ADRs, issues, or additional context
+      description: Links to ADRs under `docs/adr/`, specs under `docs/superpowers/specs/`, related issues, logs, or screenshots.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose a new capability or an enhancement to existing behaviour.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What is the user-visible problem or limitation? Why does this matter now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch the change. APIs, wire formats, UX, or behavioural changes as applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you didn't pick them. "None considered" is a valid answer for small changes.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: adr
+    attributes:
+      label: Architecture impact
+      description: novaMOC's architecture is governed by ADRs (`docs/adr/`). Check the box if this change likely needs one.
+      options:
+        - label: This change likely warrants a new or revised ADR.
+          required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, ADRs, specs, or external references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,6 +10,21 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of novaMOC does this primarily affect?
+      options:
+        - Server (Python / Litestar)
+        - Client (Svelte SPA)
+        - Sync protocol (event log / HLC / projections)
+        - Schema / ADRs / docs
+        - Tooling (uv / ruff / ty / justfile / CI)
+        - Other / unsure
+    validations:
+      required: true
+
   - type: textarea
     id: proposal
     attributes:
@@ -17,6 +32,33 @@ body:
       description: Sketch the change. APIs, wire formats, UX, or behavioural changes as applicable.
     validations:
       required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? Concrete, verifiable bullets — tests that should pass, endpoints that should return X, behaviours a user should observe.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicit non-goals. What should the implementer NOT touch or extend into? Reduces scope creep on agent-driven work.
+    validations:
+      required: false
+
+  - type: textarea
+    id: affected_files
+    attributes:
+      label: Likely affected files
+      description: Best-guess pointer to the files or modules involved. Leave blank if unsure.
+    validations:
+      required: false
 
   - type: textarea
     id: alternatives
@@ -38,7 +80,7 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: Additional context
-      description: Links to related issues, ADRs, specs, or external references.
+      label: Related ADRs, specs, plans, or additional context
+      description: Links to ADRs under `docs/adr/`, specs under `docs/superpowers/specs/`, plans under `docs/superpowers/plans/`, related issues, or external references.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -1,0 +1,64 @@
+name: Tech debt
+description: Record an existing shortcut, rough edge, or accumulated cost that should be paid down.
+labels: ["debt"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the debt.
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Where it lives
+      description: Files, modules, or subsystems involved. Link to specific lines if helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: pain
+    attributes:
+      label: Why it's debt
+      description: What's painful about the current state? Performance, correctness risk, friction when changing related code, drift from an ADR, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: remediation
+    attributes:
+      label: Proposed remediation
+      description: How would you pay it down? A rough sketch is fine — this isn't a plan.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How load-bearing is paying this down?
+      options:
+        - Low — annoyance, can sit indefinitely
+        - Medium — should be done before related work expands
+        - High — actively blocking or causing bugs
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: adr
+    attributes:
+      label: Architecture impact
+      description: Does fixing this likely touch an ADR under `docs/adr/`?
+      options:
+        - label: Remediation likely warrants a new or revised ADR.
+          required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, ADRs, prior discussion, or the commit that introduced the shortcut.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -22,7 +22,7 @@ body:
     id: pain
     attributes:
       label: Why it's debt
-      description: What's painful about the current state? Performance, correctness risk, friction when changing related code, drift from an ADR, etc.
+      description: What's painful or risky about the current state? Performance, correctness risk, friction when changing related code, drift from an ADR, etc.
     validations:
       required: true
 
@@ -38,13 +38,13 @@ body:
     id: urgency
     attributes:
       label: Urgency
-      description: How load-bearing is paying this down?
+      description: How load-bearing is paying this down? Leave blank if you don't want to take a position — the triager will decide.
       options:
         - Low — annoyance, can sit indefinitely
         - Medium — should be done before related work expands
         - High — actively blocking or causing bugs
     validations:
-      required: true
+      required: false
 
   - type: checkboxes
     id: adr
@@ -58,7 +58,7 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: Additional context
-      description: Links to related issues, ADRs, prior discussion, or the commit that introduced the shortcut.
+      label: Related ADRs, specs, issues, or additional context
+      description: Links to ADRs under `docs/adr/`, specs under `docs/superpowers/specs/`, related issues, prior discussion, or the commit that introduced the shortcut.
     validations:
       required: false


### PR DESCRIPTION
## Summary
- Adds GitHub Form templates for bug reports, feature requests, and tech debt under `.github/ISSUE_TEMPLATE/`.
- Bug template has a component dropdown matching novaMOC's structure (server / client / sync / docs / tooling / other).
- Feature template includes an ADR-needed checkbox to flag changes that touch architecture under `docs/adr/`.
- Tech-debt template captures location, why-it's-debt, an urgency dropdown, and the same ADR-impact checkbox. Labels: `debt`.
- `config.yml` disables blank issues to force users through one of the templates.

## Test plan
- [ ] Open `https://github.com/shoriminimoe/novamoc/issues/new/choose` after merge and confirm all three templates render.
- [ ] Verify the "blank issue" option is gone.
- [ ] File one throwaway issue against each template to confirm labels (`bug`, `enhancement`, `debt`) are applied automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)