### PR TITLE
feat(cli): novamoc tenant / user / auth commands (M5.13, #94)

### DIFF
--- a/.coverage-ratchet.json
+++ b/.coverage-ratchet.json
@@ -1,10 +1,10 @@
 {
   "js": {
-    "branch": 52,
-    "line": 71
+    "branch": 52.0,
+    "line": 71.0
   },
   "python": {
-    "branch": 83,
-    "line": 97
+    "branch": 84.0,
+    "line": 97.0
   }
 }

--- a/.coverage-ratchet.json
+++ b/.coverage-ratchet.json
@@ -4,7 +4,7 @@
     "line": 70.91
   },
   "python": {
-    "branch": 83.22,
-    "line": 96.68
+    "branch": 83.44,
+    "line": 96.79
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "sqlalchemy[aiosqlite,asyncio]>=2.0.49",
 ]
 
+[project.scripts]
+novamoc = "novamoc.cli:main"
+
 [build-system]
 requires = ["uv_build>=0.10.11,<0.12"]
 build-backend = "uv_build"

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 
 import click
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 # Register tenant-scoping event handlers on SQLAlchemy. Today's CLI
@@ -200,22 +201,29 @@ def user_create(username: str, password: str | None) -> None:
     )
     settings = _load_settings()
     hasher = _password_hasher(settings)
-    hashed = hasher.hash(plaintext)
 
     async def work(session: AsyncSession) -> None:
         svc = UserService(session=session)
-        # Pre-check: the service folds usernames at create-time, so a
-        # case-folded lookup catches duplicates before SQLAlchemy raises
-        # IntegrityError. The UNIQUE constraint on ``users.username``
-        # remains the structural backstop.
+        # Pre-check before hashing: the service folds usernames at
+        # create-time, so a case-folded lookup catches duplicates
+        # before the ~100 ms argon2id cost. The UNIQUE constraint on
+        # ``users.username`` remains the structural backstop.
         existing = await svc.get_by_username(username)
         if existing is not None:
             msg = f"User '{username}' already exists."
             raise click.ClickException(msg)
-        await svc.create(
-            data={"username": username, "password_hash": hashed},
-            auto_commit=False,
-        )
+        hashed = hasher.hash(plaintext)
+        try:
+            await svc.create(
+                data={"username": username, "password_hash": hashed},
+                auto_commit=False,
+            )
+        except IntegrityError as exc:
+            # Concurrent CLI invocations can race past the pre-check;
+            # the UNIQUE backstop's IntegrityError gets the same
+            # friendly message rather than a raw SQLAlchemy traceback.
+            msg = f"User '{username}' already exists."
+            raise click.ClickException(msg) from exc
 
     asyncio.run(_run_in_session(settings, work))
     click.echo(f"Created user {username}.")
@@ -239,15 +247,16 @@ def user_set_password(username: str, password: str | None) -> None:
     )
     settings = _load_settings()
     hasher = _password_hasher(settings)
-    hashed = hasher.hash(plaintext)
 
     async def work(session: AsyncSession) -> None:
         svc = UserService(session=session)
+        # Pre-check before hashing: lookup is far cheaper than the
+        # ~100 ms argon2id work for a username that doesn't exist.
         existing = await svc.get_by_username(username)
         if existing is None:
             msg = f"User '{username}' not found."
             raise click.ClickException(msg)
-        existing.password_hash = hashed
+        existing.password_hash = hasher.hash(plaintext)
         # No explicit flush — ``_run_in_session`` commits, which
         # flushes implicitly.
 
@@ -311,6 +320,12 @@ def user_add_to_tenant(username: str, tenant_uuid: str) -> None:
             # both "already" and "tenant" in the message lets the M5.15
             # bootstrap recipe (and the test) grep for the N:1 case
             # without coupling to the full sentence.
+            msg = f"User '{username}' already belongs to a tenant."
+            raise click.ClickException(msg) from exc
+        except IntegrityError as exc:
+            # Concurrent CLI invocations can race past the service-layer
+            # pre-check; the UNIQUE(user_id) backstop's IntegrityError
+            # gets the same friendly message.
             msg = f"User '{username}' already belongs to a tenant."
             raise click.ClickException(msg) from exc
 

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -55,6 +55,20 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 
+def _load_settings() -> Settings:
+    """Construct ``Settings`` with parse errors mapped to ``ClickException``.
+
+    Env-var parsing (``_int_env`` etc.) raises ``ValueError`` on a bad
+    value; surfacing that as a raw traceback contradicts the module
+    docstring's promise of a friendly stderr message. The mapping is
+    central so every command that loads settings benefits.
+    """
+    try:
+        return Settings()
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 def _password_hasher(settings: Settings) -> PasswordHasher:
     """Build a ``PasswordHasher`` from the configured auth parameters."""
     return PasswordHasher(
@@ -132,7 +146,7 @@ def tenant() -> None:
 )
 def tenant_create(display_name: str) -> None:
     """Create a tenant and print its UUID."""
-    settings = Settings()
+    settings = _load_settings()
 
     async def work(session: AsyncSession) -> uuid.UUID:
         # Return the UUID directly rather than handing back an ORM
@@ -166,7 +180,7 @@ def user() -> None:
 )
 def user_create(username: str, password: str | None) -> None:
     """Create a user with a hashed password."""
-    settings = Settings()
+    settings = _load_settings()
     hasher = _password_hasher(settings)
     plaintext = _prompt_password_if_missing(password)
     hashed = hasher.hash(plaintext)
@@ -203,7 +217,7 @@ def user_set_password(username: str, password: str | None) -> None:
     Operator-driven: no email-confirmation flow in v1. The new hash
     uses the current cost parameters from :class:`AuthSettings`.
     """
-    settings = Settings()
+    settings = _load_settings()
     hasher = _password_hasher(settings)
     plaintext = _prompt_password_if_missing(password)
     hashed = hasher.hash(plaintext)
@@ -231,7 +245,7 @@ def user_exists(username: str) -> None:
     by ``just bootstrap-dev`` (M5.15) to skip the seed when the
     target user is already provisioned.
     """
-    settings = Settings()
+    settings = _load_settings()
 
     async def work(session: AsyncSession) -> bool:
         svc = UserService(session=session)
@@ -259,7 +273,7 @@ def user_add_to_tenant(username: str, tenant_uuid: str) -> None:
         msg = f"'{tenant_uuid}' is not a valid UUID."
         raise click.ClickException(msg) from None
 
-    settings = Settings()
+    settings = _load_settings()
 
     async def work(session: AsyncSession) -> None:
         users = UserService(session=session)
@@ -303,7 +317,7 @@ def auth_gc_sessions() -> None:
     debt (ADR-020). Operators invoke this on a cadence appropriate
     to their session TTL.
     """
-    settings = Settings()
+    settings = _load_settings()
 
     async def work(session: AsyncSession) -> int:
         now = datetime.now(UTC)

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -1,0 +1,315 @@
+"""Operator CLI exposed as the ``novamoc`` console script (M5.13).
+
+The CLI is the only bootstrap path for tenants, users, and
+memberships — production deployments run it in an init container,
+local dev wires it through ``just bootstrap-dev`` (M5.15). Each
+sub-command builds its own async engine + session from
+``Settings()`` (so it picks up ``NOVAMOC_DB_URL`` and the auth
+cost parameters at invocation time), runs the operation,
+commits on success, rolls back and exits non-zero with a
+human-readable stderr message on any failure.
+
+Output convention: success messages on stdout, error messages on
+stderr. The ``tenant create`` success line ends with the new
+tenant's UUID so the M5.15 recipe can ``awk`` it out.
+
+The CLI runs outside the request lifecycle so it does not use the
+tenant-scoping middleware or contextvar. The auth-registry tables
+are not tenant-scoped (they have no ``tenant_id`` column), so the
+listeners short-circuit naturally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import click
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from novamoc.config import Settings
+from novamoc.db.models._auth import Session
+from novamoc.domain.accounts._errors import UserAlreadyHasTenantError
+from novamoc.domain.accounts._password import PasswordHasher
+from novamoc.domain.accounts._services import (
+    TenantService,
+    UserService,
+    UserTenantMembershipService,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from novamoc.db.models._auth import Tenant
+
+
+def _password_hasher(settings: Settings) -> PasswordHasher:
+    """Build a ``PasswordHasher`` from the configured auth parameters."""
+    return PasswordHasher(
+        time_cost=settings.auth.argon2_time_cost,
+        memory_cost_kib=settings.auth.argon2_memory_cost_kib,
+        parallelism=settings.auth.argon2_parallelism,
+    )
+
+
+async def _run_in_session[T](
+    settings: Settings,
+    work: Callable[[AsyncSession], Awaitable[T]],
+) -> T:
+    """Run ``work`` inside a fresh ``AsyncSession``.
+
+    Commits on success, rolls back on any exception (which then
+    propagates to the caller for the click error mapping). The
+    engine is disposed before returning so the CLI process exits
+    cleanly.
+    """
+    engine = create_async_engine(settings.db.url)
+    try:
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as session:
+            try:
+                result = await work(session)
+            except BaseException:
+                await session.rollback()
+                raise
+            await session.commit()
+            return result
+    finally:
+        await engine.dispose()
+
+
+def _prompt_password_if_missing(password: str | None) -> str:
+    """Prompt with hidden input when ``--password`` was not supplied.
+
+    Confirmation is required so a typo at the operator console does
+    not silently set an unrecoverable password.
+    """
+    if password is not None:
+        return password
+    return click.prompt("Password", hide_input=True, confirmation_prompt=True)
+
+
+def _fail(message: str) -> None:
+    """Emit ``message`` on stderr and exit non-zero."""
+    raise click.ClickException(message)
+
+
+@click.group()
+def main() -> None:
+    """novaMOC operator CLI.
+
+    Sub-groups:
+
+    * ``tenant`` — tenant registry administration.
+    * ``user`` — user registry administration.
+    * ``auth`` — session / credential maintenance.
+    """
+
+
+# ---------------------------------------------------------------------------
+# tenant
+# ---------------------------------------------------------------------------
+
+
+@main.group()
+def tenant() -> None:
+    """Tenant registry administration."""
+
+
+@tenant.command("create")
+@click.option(
+    "--display-name", required=True, help="Human-readable name for the tenant."
+)
+def tenant_create(display_name: str) -> None:
+    """Create a tenant and print its UUID."""
+    settings = Settings()
+
+    async def work(session: AsyncSession) -> Tenant:
+        svc = TenantService(session=session)
+        return await svc.create(data={"display_name": display_name}, auto_commit=False)
+
+    created = asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Created tenant {created.id}.")
+
+
+# ---------------------------------------------------------------------------
+# user
+# ---------------------------------------------------------------------------
+
+
+@main.group()
+def user() -> None:
+    """User registry administration."""
+
+
+@user.command("create")
+@click.argument("username")
+@click.option(
+    "--password",
+    default=None,
+    help="Password for the new user. Prompts interactively when omitted.",
+)
+def user_create(username: str, password: str | None) -> None:
+    """Create a user with a hashed password."""
+    settings = Settings()
+    hasher = _password_hasher(settings)
+    plaintext = _prompt_password_if_missing(password)
+    hashed = hasher.hash(plaintext)
+
+    async def work(session: AsyncSession) -> None:
+        svc = UserService(session=session)
+        # Pre-check: the service folds usernames at create-time, so a
+        # case-folded lookup catches duplicates before SQLAlchemy raises
+        # IntegrityError. The UNIQUE constraint on ``users.username``
+        # remains the structural backstop.
+        existing = await svc.get_by_username(username)
+        if existing is not None:
+            msg = f"User '{username}' already exists."
+            raise click.ClickException(msg)
+        await svc.create(
+            data={"username": username, "password_hash": hashed},
+            auto_commit=False,
+        )
+
+    asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Created user {username}.")
+
+
+@user.command("set-password")
+@click.argument("username")
+@click.option(
+    "--password",
+    default=None,
+    help="New password. Prompts interactively when omitted.",
+)
+def user_set_password(username: str, password: str | None) -> None:
+    """Reset ``<username>``'s password.
+
+    Operator-driven: no email-confirmation flow in v1. The new hash
+    uses the current cost parameters from :class:`AuthSettings`.
+    """
+    settings = Settings()
+    hasher = _password_hasher(settings)
+    plaintext = _prompt_password_if_missing(password)
+    hashed = hasher.hash(plaintext)
+
+    async def work(session: AsyncSession) -> None:
+        svc = UserService(session=session)
+        existing = await svc.get_by_username(username)
+        if existing is None:
+            msg = f"User '{username}' not found."
+            raise click.ClickException(msg)
+        existing.password_hash = hashed
+        await session.flush()
+
+    asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Password updated for user {username}.")
+
+
+@user.command("exists")
+@click.argument("username")
+def user_exists(username: str) -> None:
+    """Exit 0 if ``<username>`` exists, 1 otherwise.
+
+    Produces no stdout output — the contract is the exit code. Used
+    by ``just bootstrap-dev`` (M5.15) to skip the seed when the
+    target user is already provisioned.
+    """
+    settings = Settings()
+
+    async def work(session: AsyncSession) -> bool:
+        svc = UserService(session=session)
+        return (await svc.get_by_username(username)) is not None
+
+    found = asyncio.run(_run_in_session(settings, work))
+    if not found:
+        sys.exit(1)
+
+
+@user.command("add-to-tenant")
+@click.argument("username")
+@click.argument("tenant_uuid")
+def user_add_to_tenant(username: str, tenant_uuid: str) -> None:
+    """Add ``<username>`` to ``<tenant-uuid>`` as a membership.
+
+    The N:1 invariant (ADR-020, v1) is enforced by
+    :class:`UserTenantMembershipService`; the CLI surfaces that
+    rejection as a non-zero exit with a message containing
+    "already" and "tenant".
+    """
+    try:
+        tenant_id = uuid.UUID(tenant_uuid)
+    except ValueError:
+        msg = f"'{tenant_uuid}' is not a valid UUID."
+        raise click.ClickException(msg) from None
+
+    settings = Settings()
+
+    async def work(session: AsyncSession) -> None:
+        users = UserService(session=session)
+        target = await users.get_by_username(username)
+        if target is None:
+            msg = f"User '{username}' not found."
+            raise click.ClickException(msg)
+        memberships = UserTenantMembershipService(session=session)
+        try:
+            await memberships.create(
+                data={"user_id": target.id, "tenant_id": tenant_id},
+                auto_commit=False,
+            )
+        except UserAlreadyHasTenantError as exc:
+            # Surface the friendly rejection as a CLI failure. Keeping
+            # both "already" and "tenant" in the message lets the M5.15
+            # bootstrap recipe (and the test) grep for the N:1 case
+            # without coupling to the full sentence.
+            msg = f"User '{username}' already belongs to a tenant."
+            raise click.ClickException(msg) from exc
+
+    asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Added user {username} to tenant {tenant_id}.")
+
+
+# ---------------------------------------------------------------------------
+# auth
+# ---------------------------------------------------------------------------
+
+
+@main.group()
+def auth() -> None:
+    """Session / credential maintenance."""
+
+
+@auth.command("gc-sessions")
+def auth_gc_sessions() -> None:
+    """Delete expired ``sessions`` rows and print the count.
+
+    Opportunistic GC; the design records a future scheduler as tech
+    debt (ADR-020). Operators invoke this on a cadence appropriate
+    to their session TTL.
+    """
+    settings = Settings()
+
+    async def work(session: AsyncSession) -> int:
+        now = datetime.now(UTC)
+        table = Session.__table__
+        stmt = delete(table).where(table.c.expires_at < now)  # ty: ignore[invalid-argument-type]
+        result = await session.execute(stmt)
+        # ``Result.rowcount`` is reliable for DELETE on SQLite under
+        # SQLAlchemy 2.x; the few backends that mark it ``-1`` for
+        # bulk DML do not include the dialects this project targets.
+        # The static type is ``Result[Any]`` (the typed base), which
+        # does not expose ``rowcount`` — the attribute lives on
+        # ``CursorResult``. The same pattern in
+        # ``domain/events/_row_state.py`` survives ty because the
+        # ``session`` there is unannotated; here we keep the annotation
+        # and accept the narrow ignore.
+        return result.rowcount or 0  # ty: ignore[unresolved-attribute]
+
+    deleted = asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Deleted {deleted} expired sessions.")

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -202,7 +202,7 @@ def user_create(username: str, password: str | None) -> None:
     settings = _load_settings()
     hasher = _password_hasher(settings)
 
-    async def work(session: AsyncSession) -> None:
+    async def work(session: AsyncSession) -> str:
         svc = UserService(session=session)
         # Pre-check before hashing: the service folds usernames at
         # create-time, so a case-folded lookup catches duplicates
@@ -214,7 +214,7 @@ def user_create(username: str, password: str | None) -> None:
             raise click.ClickException(msg)
         hashed = hasher.hash(plaintext)
         try:
-            await svc.create(
+            created = await svc.create(
                 data={"username": username, "password_hash": hashed},
                 auto_commit=False,
             )
@@ -224,9 +224,10 @@ def user_create(username: str, password: str | None) -> None:
             # friendly message rather than a raw SQLAlchemy traceback.
             msg = f"User '{username}' already exists."
             raise click.ClickException(msg) from exc
+        return created.username
 
-    asyncio.run(_run_in_session(settings, work))
-    click.echo(f"Created user {username}.")
+    folded = asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Created user {folded}.")
 
 
 @user.command("set-password")
@@ -248,7 +249,7 @@ def user_set_password(username: str, password: str | None) -> None:
     settings = _load_settings()
     hasher = _password_hasher(settings)
 
-    async def work(session: AsyncSession) -> None:
+    async def work(session: AsyncSession) -> str:
         svc = UserService(session=session)
         # Pre-check before hashing: lookup is far cheaper than the
         # ~100 ms argon2id work for a username that doesn't exist.
@@ -259,9 +260,10 @@ def user_set_password(username: str, password: str | None) -> None:
         existing.password_hash = hasher.hash(plaintext)
         # No explicit flush — ``_run_in_session`` commits, which
         # flushes implicitly.
+        return existing.username
 
-    asyncio.run(_run_in_session(settings, work))
-    click.echo(f"Password updated for user {username}.")
+    folded = asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Password updated for user {folded}.")
 
 
 @user.command("exists")
@@ -303,7 +305,7 @@ def user_add_to_tenant(username: str, tenant_uuid: str) -> None:
 
     settings = _load_settings()
 
-    async def work(session: AsyncSession) -> None:
+    async def work(session: AsyncSession) -> str:
         users = UserService(session=session)
         target = await users.get_by_username(username)
         if target is None:
@@ -336,9 +338,10 @@ def user_add_to_tenant(username: str, tenant_uuid: str) -> None:
             # gets the same friendly message.
             msg = f"User '{username}' already belongs to a tenant."
             raise click.ClickException(msg) from exc
+        return target.username
 
-    asyncio.run(_run_in_session(settings, work))
-    click.echo(f"Added user {username} to tenant {tenant_id}.")
+    folded = asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Added user {folded} to tenant {tenant_id}.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -269,19 +269,31 @@ def user_set_password(username: str, password: str | None) -> None:
 @user.command("exists")
 @click.argument("username")
 def user_exists(username: str) -> None:
-    """Exit 0 if ``<username>`` exists, 1 otherwise.
+    """Exit 0 if ``<username>`` exists, 1 if absent, 2 on CLI error.
 
     Produces no stdout output — the contract is the exit code. Used
     by ``just bootstrap-dev`` (M5.15) to skip the seed when the
-    target user is already provisioned.
+    target user is already provisioned. The three-way exit lets the
+    bootstrap recipe distinguish "user absent, seed now" (exit 1)
+    from "CLI errored, abort" (exit 2).
     """
-    settings = _load_settings()
 
     async def work(session: AsyncSession) -> bool:
         svc = UserService(session=session)
         return (await svc.get_by_username(username)) is not None
 
-    found = asyncio.run(_run_in_session(settings, work))
+    try:
+        settings = _load_settings()
+        found = asyncio.run(_run_in_session(settings, work))
+    except click.ClickException as exc:
+        # Translate the standard ClickException exit (1) into exit 2
+        # so the absent-user case (exit 1, below) stays distinct.
+        click.echo(f"Error: {exc.format_message()}", err=True)
+        sys.exit(2)
+    except Exception as exc:  # noqa: BLE001 — terminal CLI handler, exit-code contract
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
     if not found:
         sys.exit(1)
 

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -309,6 +309,14 @@ def user_add_to_tenant(username: str, tenant_uuid: str) -> None:
         if target is None:
             msg = f"User '{username}' not found."
             raise click.ClickException(msg)
+        # Explicit tenant existence check: PRAGMA ``foreign_keys=ON``
+        # is not yet wired (see ``_membership.py``), so without this
+        # lookup a phantom tenant UUID would silently produce an
+        # orphan membership row.
+        tenants = TenantService(session=session)
+        if not await tenants.exists(id=tenant_id):
+            msg = f"Tenant '{tenant_id}' not found."
+            raise click.ClickException(msg)
         memberships = UserTenantMembershipService(session=session)
         try:
             await memberships.create(

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -118,6 +118,20 @@ def _prompt_password_if_missing(password: str | None) -> str:
     return click.prompt("Password", hide_input=True, confirmation_prompt=True)
 
 
+def _require_nonblank(value: str, *, label: str) -> str:
+    """Return ``value`` if non-blank; else raise ``ClickException``.
+
+    Click's ``required=True`` only rejects absent options; the prompt
+    fallback similarly accepts empty input when ``--password ''`` is
+    explicitly passed. This helper is the single chokepoint for
+    rejecting whitespace-only or empty strings on operator inputs.
+    """
+    if not value.strip():
+        msg = f"{label} must not be empty."
+        raise click.ClickException(msg)
+    return value
+
+
 @click.group()
 def main() -> None:
     """novaMOC operator CLI.
@@ -146,6 +160,7 @@ def tenant() -> None:
 )
 def tenant_create(display_name: str) -> None:
     """Create a tenant and print its UUID."""
+    _require_nonblank(display_name, label="--display-name")
     settings = _load_settings()
 
     async def work(session: AsyncSession) -> uuid.UUID:
@@ -180,9 +195,11 @@ def user() -> None:
 )
 def user_create(username: str, password: str | None) -> None:
     """Create a user with a hashed password."""
+    plaintext = _require_nonblank(
+        _prompt_password_if_missing(password), label="Password"
+    )
     settings = _load_settings()
     hasher = _password_hasher(settings)
-    plaintext = _prompt_password_if_missing(password)
     hashed = hasher.hash(plaintext)
 
     async def work(session: AsyncSession) -> None:
@@ -217,9 +234,11 @@ def user_set_password(username: str, password: str | None) -> None:
     Operator-driven: no email-confirmation flow in v1. The new hash
     uses the current cost parameters from :class:`AuthSettings`.
     """
+    plaintext = _require_nonblank(
+        _prompt_password_if_missing(password), label="Password"
+    )
     settings = _load_settings()
     hasher = _password_hasher(settings)
-    plaintext = _prompt_password_if_missing(password)
     hashed = hasher.hash(plaintext)
 
     async def work(session: AsyncSession) -> None:

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -16,7 +16,9 @@ tenant's UUID so the M5.15 recipe can ``awk`` it out.
 The CLI runs outside the request lifecycle so it does not use the
 tenant-scoping middleware or contextvar. The auth-registry tables
 are not tenant-scoped (they have no ``tenant_id`` column), so the
-listeners short-circuit naturally.
+listeners short-circuit naturally. We still import the listeners
+module so any future CLI command that touches a synced table goes
+through the same structural enforcement as the web layer.
 """
 
 from __future__ import annotations
@@ -31,6 +33,12 @@ import click
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+# Register tenant-scoping event handlers on SQLAlchemy. Today's CLI
+# commands only touch the non-scoped auth-registry tables so the
+# listeners short-circuit, but importing here keeps the production
+# CLI path aligned with ``asgi.create_app`` for any future command
+# that touches a synced table.
+import novamoc.db._listeners  # noqa: F401
 from novamoc.config import Settings
 from novamoc.db.models._auth import Session
 from novamoc.domain.accounts._errors import UserAlreadyHasTenantError
@@ -45,8 +53,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from sqlalchemy.ext.asyncio import AsyncSession
-
-    from novamoc.db.models._auth import Tenant
 
 
 def _password_hasher(settings: Settings) -> PasswordHasher:
@@ -67,7 +73,10 @@ async def _run_in_session[T](
     Commits on success, rolls back on any exception (which then
     propagates to the caller for the click error mapping). The
     engine is disposed before returning so the CLI process exits
-    cleanly.
+    cleanly. ``commit`` runs inside the same ``try`` as ``work`` so
+    a commit-time failure (deferred constraint, future commit-hook)
+    follows the explicit rollback path rather than relying on
+    ``AsyncSession.close()``'s implicit rollback.
     """
     engine = create_async_engine(settings.db.url)
     try:
@@ -75,10 +84,10 @@ async def _run_in_session[T](
         async with factory() as session:
             try:
                 result = await work(session)
+                await session.commit()
             except BaseException:
                 await session.rollback()
                 raise
-            await session.commit()
             return result
     finally:
         await engine.dispose()
@@ -93,11 +102,6 @@ def _prompt_password_if_missing(password: str | None) -> str:
     if password is not None:
         return password
     return click.prompt("Password", hide_input=True, confirmation_prompt=True)
-
-
-def _fail(message: str) -> None:
-    """Emit ``message`` on stderr and exit non-zero."""
-    raise click.ClickException(message)
 
 
 @click.group()
@@ -130,12 +134,17 @@ def tenant_create(display_name: str) -> None:
     """Create a tenant and print its UUID."""
     settings = Settings()
 
-    async def work(session: AsyncSession) -> Tenant:
+    async def work(session: AsyncSession) -> uuid.UUID:
+        # Return the UUID directly rather than handing back an ORM
+        # instance whose attributes would be read after ``engine.dispose()``.
         svc = TenantService(session=session)
-        return await svc.create(data={"display_name": display_name}, auto_commit=False)
+        created = await svc.create(
+            data={"display_name": display_name}, auto_commit=False
+        )
+        return created.id
 
-    created = asyncio.run(_run_in_session(settings, work))
-    click.echo(f"Created tenant {created.id}.")
+    created_id = asyncio.run(_run_in_session(settings, work))
+    click.echo(f"Created tenant {created_id}.")
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +215,8 @@ def user_set_password(username: str, password: str | None) -> None:
             msg = f"User '{username}' not found."
             raise click.ClickException(msg)
         existing.password_hash = hashed
-        await session.flush()
+        # No explicit flush — ``_run_in_session`` commits, which
+        # flushes implicitly.
 
     asyncio.run(_run_in_session(settings, work))
     click.echo(f"Password updated for user {username}.")

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -308,3 +308,20 @@ def test_user_add_to_tenant_echoes_folded_username(
     assert result.exit_code == 0, (result.output, result.stderr)
     assert "ALICE" not in result.stdout
     assert "alice" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# user exists exit-code semantics ([7] in the PR #115 review)
+# ---------------------------------------------------------------------------
+
+
+def test_user_exists_returns_two_on_db_error(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exit 2 distinguishes 'CLI errored' from 'user absent' (exit 1)."""
+    # Point at a directory that exists but a path that is the directory itself,
+    # so the SQLite connection cannot open it.
+    bad_url = f"sqlite+aiosqlite:///{tmp_path}"
+    monkeypatch.setenv("NOVAMOC_DB_URL", bad_url)
+    result = runner.invoke(main, ["user", "exists", "ghost"])
+    assert result.exit_code == 2, (result.exit_code, result.output, result.stderr)

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -18,17 +18,21 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import pytest
 from advanced_alchemy.base import metadata_registry
 from click.testing import CliRunner
+from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import create_async_engine
 
 # Importing the models registers their tables on the shared metadata
 # registry so ``create_all`` below picks them up.
 import novamoc.db.models  # noqa: F401
 from novamoc.cli import main
+from novamoc.db.models._auth import Session, User
+from novamoc.domain.accounts._password import PasswordHasher
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -123,6 +127,33 @@ def test_user_set_password_succeeds(runner: CliRunner, db_url: str) -> None:
     assert result.exit_code == 0, (result.output, result.stderr)
 
 
+def test_user_set_password_persists_new_hash(runner: CliRunner, db_url: str) -> None:
+    """The new hash actually persists — a missing flush/commit would regress this."""
+    runner.invoke(main, ["user", "create", "alice", "--password", "old"])
+    result = runner.invoke(main, ["user", "set-password", "alice", "--password", "new"])
+    assert result.exit_code == 0, (result.output, result.stderr)
+
+    async def _hash() -> str:
+        eng = create_async_engine(db_url)
+        try:
+            async with eng.connect() as conn:
+                row = (
+                    await conn.execute(
+                        select(User.__table__.c.password_hash).where(
+                            User.__table__.c.username == "alice"
+                        )
+                    )
+                ).one()
+                return row[0]
+        finally:
+            await eng.dispose()
+
+    stored = asyncio.run(_hash())
+    hasher = PasswordHasher()
+    assert hasher.verify(stored, "new") is True
+    assert hasher.verify(stored, "old") is False
+
+
 def test_user_set_password_missing_user_exits_nonzero(
     runner: CliRunner, db_url: str
 ) -> None:
@@ -201,6 +232,58 @@ def test_auth_gc_sessions_on_empty_table_prints_count(
     result = runner.invoke(main, ["auth", "gc-sessions"])
     assert result.exit_code == 0, (result.output, result.stderr)
     assert "Deleted 0 expired sessions." in result.stdout
+
+
+def test_auth_gc_sessions_deletes_only_expired(
+    runner: CliRunner, db_url: str
+) -> None:
+    """Seed one expired and one live session; only the expired row is deleted."""
+
+    async def _seed() -> tuple[uuid.UUID, uuid.UUID]:
+        eng = create_async_engine(db_url)
+        try:
+            async with eng.begin() as conn:
+                now = datetime.now(UTC)
+                expired_id = uuid.uuid4()
+                live_id = uuid.uuid4()
+                await conn.execute(
+                    insert(Session).values(
+                        id=expired_id,
+                        session_id="expired-sid",
+                        data=b"",
+                        expires_at=now - timedelta(hours=1),
+                    )
+                )
+                await conn.execute(
+                    insert(Session).values(
+                        id=live_id,
+                        session_id="live-sid",
+                        data=b"",
+                        expires_at=now + timedelta(hours=1),
+                    )
+                )
+                return expired_id, live_id
+        finally:
+            await eng.dispose()
+
+    expired_id, live_id = asyncio.run(_seed())
+
+    result = runner.invoke(main, ["auth", "gc-sessions"])
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert "Deleted 1 expired sessions." in result.stdout
+
+    async def _remaining() -> list[uuid.UUID]:
+        eng = create_async_engine(db_url)
+        try:
+            async with eng.connect() as conn:
+                rows = await conn.execute(select(Session.__table__.c.id))
+                return [r[0] for r in rows.all()]
+        finally:
+            await eng.dispose()
+
+    remaining = asyncio.run(_remaining())
+    assert expired_id not in remaining
+    assert live_id in remaining
 
 
 # ---------------------------------------------------------------------------

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -257,3 +257,20 @@ def test_settings_parse_error_renders_as_clickexception(
     # would not appear in click's stderr formatting.
     assert "NOVAMOC_AUTH_ARGON2_TIME_COST" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Missing tenant on add-to-tenant ([1] in the PR #115 review)
+# ---------------------------------------------------------------------------
+
+
+def test_user_add_to_tenant_unknown_tenant_exits_nonzero(
+    runner: CliRunner, db_url: str
+) -> None:
+    """FK PRAGMA is not wired yet; an explicit lookup must catch a phantom UUID."""
+    runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+    phantom = uuid.uuid4()
+    result = runner.invoke(main, ["user", "add-to-tenant", "alice", str(phantom)])
+    assert result.exit_code != 0
+    assert "not found" in result.stderr.lower()
+    assert str(phantom) in result.stderr

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -201,3 +201,21 @@ def test_auth_gc_sessions_on_empty_table_prints_count(
     result = runner.invoke(main, ["auth", "gc-sessions"])
     assert result.exit_code == 0, (result.output, result.stderr)
     assert "Deleted 0 expired sessions." in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Settings parse-error mapping ([5] in the PR #115 review)
+# ---------------------------------------------------------------------------
+
+
+def test_settings_parse_error_renders_as_clickexception(
+    runner: CliRunner, db_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bad env-var value exits with a friendly message, not a raw traceback."""
+    monkeypatch.setenv("NOVAMOC_AUTH_ARGON2_TIME_COST", "not-an-int")
+    result = runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+    assert result.exit_code != 0
+    # Friendly message includes the offending env var; raw ValueError tracebacks
+    # would not appear in click's stderr formatting.
+    assert "NOVAMOC_AUTH_ARGON2_TIME_COST" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -274,3 +274,37 @@ def test_user_add_to_tenant_unknown_tenant_exits_nonzero(
     assert result.exit_code != 0
     assert "not found" in result.stderr.lower()
     assert str(phantom) in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Echoed username uses the folded form ([9] in the PR #115 review)
+# ---------------------------------------------------------------------------
+
+
+def test_user_create_echoes_folded_username(runner: CliRunner, db_url: str) -> None:
+    result = runner.invoke(main, ["user", "create", "ALICE", "--password", "x"])
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert "ALICE" not in result.stdout
+    assert "alice" in result.stdout
+
+
+def test_user_set_password_echoes_folded_username(
+    runner: CliRunner, db_url: str
+) -> None:
+    runner.invoke(main, ["user", "create", "alice", "--password", "old"])
+    result = runner.invoke(main, ["user", "set-password", "ALICE", "--password", "new"])
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert "ALICE" not in result.stdout
+    assert "alice" in result.stdout
+
+
+def test_user_add_to_tenant_echoes_folded_username(
+    runner: CliRunner, db_url: str
+) -> None:
+    tenant_res = runner.invoke(main, ["tenant", "create", "--display-name", "Acme"])
+    tenant_id = _extract_uuid(tenant_res.stdout)
+    runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+    result = runner.invoke(main, ["user", "add-to-tenant", "ALICE", str(tenant_id)])
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert "ALICE" not in result.stdout
+    assert "alice" in result.stdout

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -204,6 +204,44 @@ def test_auth_gc_sessions_on_empty_table_prints_count(
 
 
 # ---------------------------------------------------------------------------
+# Empty-string rejection ([2] / [8] in the PR #115 review)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("password", ["", "   ", "\t\n"])
+def test_user_create_empty_password_exits_nonzero(
+    runner: CliRunner, db_url: str, password: str
+) -> None:
+    result = runner.invoke(main, ["user", "create", "alice", "--password", password])
+    assert result.exit_code != 0
+    assert "password" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("password", ["", "   ", "\t\n"])
+def test_user_set_password_empty_password_exits_nonzero(
+    runner: CliRunner, db_url: str, password: str
+) -> None:
+    runner.invoke(main, ["user", "create", "alice", "--password", "old"])
+    result = runner.invoke(
+        main, ["user", "set-password", "alice", "--password", password]
+    )
+    assert result.exit_code != 0
+    assert "password" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("display_name", ["", "   ", "\t\n"])
+def test_tenant_create_empty_display_name_exits_nonzero(
+    runner: CliRunner, db_url: str, display_name: str
+) -> None:
+    result = runner.invoke(main, ["tenant", "create", "--display-name", display_name])
+    assert result.exit_code != 0
+    assert (
+        "display-name" in result.stderr.lower()
+        or "display_name" in result.stderr.lower()
+    )
+
+
+# ---------------------------------------------------------------------------
 # Settings parse-error mapping ([5] in the PR #115 review)
 # ---------------------------------------------------------------------------
 

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -1,0 +1,203 @@
+"""Tests for the ``novamoc`` operator CLI (M5.13).
+
+The CLI builds its own engine + session from ``Settings()`` and runs
+outside the request lifecycle, so each test points
+``NOVAMOC_DB_URL`` at a per-test SQLite file via ``monkeypatch`` and
+seeds the schema via ``metadata.create_all``. The CLI commands are
+the production bootstrap path (init container / ``just bootstrap-dev``);
+these tests pin the contract those scripts depend on.
+
+The auth-registry tables (``users``, ``tenants``,
+``user_tenant_memberships``, ``sessions``) are not tenant-scoped, so
+the autouse tenant fixture has nothing to do here — every test in
+this module opts out via ``no_tenant``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from advanced_alchemy.base import metadata_registry
+from click.testing import CliRunner
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# Importing the models registers their tables on the shared metadata
+# registry so ``create_all`` below picks them up.
+import novamoc.db.models  # noqa: F401
+from novamoc.cli import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.no_tenant
+
+
+@pytest.fixture
+def db_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Point ``NOVAMOC_DB_URL`` at a per-test SQLite file and seed schema.
+
+    Returns the URL so individual tests can assert against the same DB
+    directly if they need to. The CLI reads ``Settings()`` on every
+    invocation, so setting the env var via ``monkeypatch`` is enough to
+    redirect it.
+    """
+    path = tmp_path / "novamoc.sqlite"
+    url = f"sqlite+aiosqlite:///{path}"
+    monkeypatch.setenv("NOVAMOC_DB_URL", url)
+
+    async def _create() -> None:
+        eng = create_async_engine(url)
+        try:
+            async with eng.begin() as conn:
+                for key in metadata_registry:
+                    await conn.run_sync(metadata_registry[key].create_all)
+        finally:
+            await eng.dispose()
+
+    asyncio.run(_create())
+    return url
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    # Click 8.3 removed the ``mix_stderr`` knob — stdout/stderr are
+    # separate by default, which is the behaviour the assertions below
+    # rely on (e.g. ``user exists`` must produce empty stdout).
+    return CliRunner()
+
+
+_UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
+)
+
+
+def _extract_uuid(text: str) -> uuid.UUID:
+    match = _UUID_RE.search(text)
+    assert match is not None, f"no UUID found in {text!r}"
+    return uuid.UUID(match.group(0))
+
+
+def test_help_lists_groups(runner: CliRunner) -> None:
+    """``novamoc --help`` enumerates the three sub-groups."""
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0, result.output
+    for group in ("tenant", "user", "auth"):
+        assert group in result.output
+
+
+def test_tenant_create_prints_uuid(runner: CliRunner, db_url: str) -> None:
+    result = runner.invoke(main, ["tenant", "create", "--display-name", "Acme"])
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert result.stdout.startswith("Created tenant ")
+    # Parseable UUID at the end of the output — what the recipe will awk for.
+    _extract_uuid(result.stdout)
+
+
+def test_user_create_succeeds(runner: CliRunner, db_url: str) -> None:
+    result = runner.invoke(
+        main, ["user", "create", "alice", "--password", "correct horse"]
+    )
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert "alice" in result.stdout.lower()
+
+
+def test_user_create_duplicate_exits_nonzero(runner: CliRunner, db_url: str) -> None:
+    first = runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(main, ["user", "create", "alice", "--password", "y"])
+    assert second.exit_code != 0
+    assert "already exists" in second.stderr.lower()
+    assert "alice" in second.stderr.lower()
+
+
+def test_user_set_password_succeeds(runner: CliRunner, db_url: str) -> None:
+    runner.invoke(main, ["user", "create", "alice", "--password", "old"])
+
+    result = runner.invoke(main, ["user", "set-password", "alice", "--password", "new"])
+    assert result.exit_code == 0, (result.output, result.stderr)
+
+
+def test_user_set_password_missing_user_exits_nonzero(
+    runner: CliRunner, db_url: str
+) -> None:
+    result = runner.invoke(main, ["user", "set-password", "ghost", "--password", "x"])
+    assert result.exit_code != 0
+    assert "not found" in result.stderr.lower()
+    assert "ghost" in result.stderr.lower()
+
+
+def test_user_exists_returns_zero_after_create(runner: CliRunner, db_url: str) -> None:
+    runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+
+    result = runner.invoke(main, ["user", "exists", "alice"])
+    assert result.exit_code == 0
+    # No stdout output — only the exit code is the contract.
+    assert result.stdout == ""
+
+
+def test_user_exists_returns_one_for_missing(runner: CliRunner, db_url: str) -> None:
+    result = runner.invoke(main, ["user", "exists", "ghost"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+
+
+def test_user_add_to_tenant_succeeds(runner: CliRunner, db_url: str) -> None:
+    tenant_res = runner.invoke(main, ["tenant", "create", "--display-name", "Acme"])
+    tenant_id = _extract_uuid(tenant_res.stdout)
+
+    runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+
+    result = runner.invoke(main, ["user", "add-to-tenant", "alice", str(tenant_id)])
+    assert result.exit_code == 0, (result.output, result.stderr)
+
+
+def test_user_add_to_tenant_invalid_uuid_exits_nonzero(
+    runner: CliRunner, db_url: str
+) -> None:
+    runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+
+    result = runner.invoke(main, ["user", "add-to-tenant", "alice", "not-a-uuid"])
+    assert result.exit_code != 0
+    assert "not a valid uuid" in result.stderr.lower()
+
+
+def test_user_add_to_tenant_missing_user_exits_nonzero(
+    runner: CliRunner, db_url: str
+) -> None:
+    tenant_res = runner.invoke(main, ["tenant", "create", "--display-name", "Acme"])
+    tenant_id = _extract_uuid(tenant_res.stdout)
+
+    result = runner.invoke(main, ["user", "add-to-tenant", "ghost", str(tenant_id)])
+    assert result.exit_code != 0
+    assert "not found" in result.stderr.lower()
+
+
+def test_user_add_to_tenant_already_has_tenant_exits_nonzero(
+    runner: CliRunner, db_url: str
+) -> None:
+    """The N:1 invariant rejection — the CLI side of M5.4."""
+    first = runner.invoke(main, ["tenant", "create", "--display-name", "Alpha"])
+    first_tid = _extract_uuid(first.stdout)
+    second = runner.invoke(main, ["tenant", "create", "--display-name", "Bravo"])
+    second_tid = _extract_uuid(second.stdout)
+
+    runner.invoke(main, ["user", "create", "alice", "--password", "x"])
+    runner.invoke(main, ["user", "add-to-tenant", "alice", str(first_tid)])
+
+    result = runner.invoke(main, ["user", "add-to-tenant", "alice", str(second_tid)])
+    assert result.exit_code != 0
+    assert re.search(r"already.*tenant", result.stderr, re.IGNORECASE)
+
+
+def test_auth_gc_sessions_on_empty_table_prints_count(
+    runner: CliRunner, db_url: str
+) -> None:
+    result = runner.invoke(main, ["auth", "gc-sessions"])
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert "Deleted 0 expired sessions." in result.stdout

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -234,9 +234,7 @@ def test_auth_gc_sessions_on_empty_table_prints_count(
     assert "Deleted 0 expired sessions." in result.stdout
 
 
-def test_auth_gc_sessions_deletes_only_expired(
-    runner: CliRunner, db_url: str
-) -> None:
+def test_auth_gc_sessions_deletes_only_expired(runner: CliRunner, db_url: str) -> None:
     """Seed one expired and one live session; only the expired row is deleted."""
 
     async def _seed() -> tuple[uuid.UUID, uuid.UUID]:


### PR DESCRIPTION
Closes #94.

## Summary

Adds the Click-based ``novamoc`` operator CLI as the sole bootstrap path for tenants, users, and memberships. Production deployments run it in an init container; local dev will wire it through ``just bootstrap-dev`` (M5.15, follow-up).

Each sub-command opens its own ``AsyncSession`` against the engine built from ``Settings()`` (so ``NOVAMOC_DB_URL`` and the argon2 cost parameters are read at invocation time), commits on success, and exits non-zero with a human-readable stderr message on failure. The CLI runs outside the request lifecycle; the auth-registry tables are not tenant-scoped, so the listeners short-circuit naturally on column absence.

## Commands

- ``novamoc tenant create --display-name <name>`` — prints ``Created tenant <uuid>.`` so M5.15 can ``awk`` the new id out.
- ``novamoc user create <username> [--password <pw>]`` — hashes via ``PasswordHasher`` from ``AuthSettings``; pre-checks for case-folded duplicates so the operator gets a friendly ``User '<x>' already exists.`` before the ``UNIQUE`` backstop fires. Without ``--password``, prompts interactively (``hide_input=True``, confirmation).
- ``novamoc user set-password <username> [--password <pw>]`` — operator-driven reset (no email flow in v1). New hash uses current cost parameters.
- ``novamoc user exists <username>`` — exit 0 / 1 only, no stdout output. Used to short-circuit the M5.15 bootstrap when the seed user is already present.
- ``novamoc user add-to-tenant <username> <tenant-uuid>`` — username lookup is case-folded via ``UserService.get_by_username``. Surfaces ``UserAlreadyHasTenantError`` from M5.4 as a CLI failure containing both "already" and "tenant" so the bootstrap recipe can grep for the N:1 case without coupling to the full sentence. Invalid UUID syntax exits with ``'<x>' is not a valid UUID.``
- ``novamoc auth gc-sessions`` — opportunistic GC of expired ``sessions`` rows; prints ``Deleted N expired sessions.`` A future scheduler makes this automatic.

## Non-goals

- ``just bootstrap-dev`` is M5.15, not in this PR.
- Wire-level mapping of ``UserAlreadyHasTenantError`` to 409 problem-details lives on the HTTP surface; the CLI uses the same exception only for its exit code.
- No historical / as-of-seq operations.

## Test plan

- [x] ``uv run pytest tests/accounts/test_cli.py`` — 13 tests covering: ``--help`` lists groups; ``tenant create`` prints a parseable UUID; ``user create`` succeeds and rejects duplicates; ``set-password`` succeeds and rejects missing users; ``user exists`` returns 0/1 with no stdout; ``add-to-tenant`` succeeds, rejects invalid UUIDs, rejects missing users, and rejects the second tenant for an already-mapped user (the M5.4 invariant test on the CLI side); ``auth gc-sessions`` runs cleanly on an empty table.
- [x] ``uv run novamoc --help`` prints the command tree.
- [x] ``just lint``, ``just typecheck``, ``just test-py`` all clean.
- [x] ``just ratchet`` clean (coverage baseline bumped to reflect the new CLI tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)