### PR TITLE
feat(accounts): login / logout / me handlers + AuthController (M5.10, #91)

### DIFF
--- a/src/py/novamoc/domain/accounts/_handlers.py
+++ b/src/py/novamoc/domain/accounts/_handlers.py
@@ -1,0 +1,137 @@
+"""Module-level handler functions for the ``/auth`` routes (M5.10, #91).
+
+The :class:`AuthController` in :mod:`novamoc.domain.accounts.controllers._auth`
+is a thin wrapper that resolves DI and forwards to these functions; the
+business logic lives here so the handlers stay individually unit-testable
+against the in-memory engine fixtures.
+
+Anti-enumeration: every failure path in :func:`login` (unknown user,
+wrong password, disabled user, zero memberships) raises the same
+:class:`LoginFailedError` so the wire byte-pattern is identical across
+shapes (ADR-020).
+
+The session middleware that gives ``request.set_session`` /
+``request.clear_session`` their teeth lands in M5.11; the handlers here
+are written against the Litestar surface and treat the middleware mount
+as a separate concern.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from novamoc.domain.accounts._errors import LoginFailedError
+from novamoc.domain.accounts._payloads import (
+    MePrincipal,
+    MeResponse,
+    MeTenant,
+)
+
+if TYPE_CHECKING:
+    from novamoc.domain.accounts._auth import RequestAuth
+    from novamoc.domain.accounts._password import PasswordHasher
+    from novamoc.domain.accounts._payloads import LoginRequest
+    from novamoc.domain.accounts._principal import Principal
+    from novamoc.domain.accounts._services import (
+        TenantService,
+        UserService,
+        UserTenantMembershipService,
+    )
+
+
+class _LoginRequest(Protocol):
+    """Surface of :class:`litestar.Request` the login handler touches."""
+
+    def set_session(self, data: dict[str, Any], /) -> None: ...
+
+
+class _LogoutRequest(Protocol):
+    """Surface of :class:`litestar.Request` the logout handler touches."""
+
+    def clear_session(self) -> None: ...
+
+
+class _MeRequest(Protocol):
+    """Surface of :class:`litestar.Request` the me handler reads."""
+
+    @property
+    def user(self) -> Principal: ...
+
+    @property
+    def auth(self) -> RequestAuth: ...
+
+
+async def login(
+    *,
+    request: _LoginRequest,
+    data: LoginRequest,
+    users: UserService,
+    memberships: UserTenantMembershipService,
+    password_hasher: PasswordHasher,
+) -> None:
+    """Authenticate the request and seed a session.
+
+    Folds every credential-rejection path into a single
+    :class:`LoginFailedError`: unknown user, wrong password, disabled
+    user, and the transient zero-membership case all share one wire
+    body (ADR-020). On success the handler writes the session payload
+    via :meth:`Request.set_session` — the session middleware (M5.11)
+    serializes it and emits the ``Set-Cookie`` header.
+
+    A successful verify against an out-of-date hash triggers a free
+    upgrade: the user's ``password_hash`` is rewritten with the current
+    cost parameters so cost rotations propagate as users log in.
+
+    Raises:
+        LoginFailedError: any credential-rejection path.
+    """
+    user = await users.get_by_username(data.username)
+    if user is None or user.disabled_at is not None:
+        raise LoginFailedError
+
+    plaintext = data.password.get_secret_value()
+    if not password_hasher.verify(user.password_hash, plaintext):
+        raise LoginFailedError
+
+    membership = await memberships.get_for_user(user.id)
+    if membership is None:
+        raise LoginFailedError
+
+    if password_hasher.check_needs_rehash(user.password_hash):
+        await users.update(
+            data={"password_hash": password_hasher.hash(plaintext)},
+            item_id=user.id,
+            auto_commit=False,
+        )
+
+    request.set_session(
+        {
+            "user_id": str(user.id),
+            "active_tenant_id": str(membership.tenant_id),
+        }
+    )
+
+
+async def logout(*, request: _LogoutRequest) -> None:
+    """Clear the session.
+
+    The session middleware (M5.11) emits the cookie-clearing
+    ``Set-Cookie`` header and deletes the backend row.
+    """
+    request.clear_session()
+
+
+async def me(*, request: _MeRequest, tenants: TenantService) -> MeResponse:
+    """Return the active user / tenant pair for the current session.
+
+    Reads :attr:`Request.user` (the :class:`Principal`) and
+    :attr:`Request.auth` (the :class:`RequestAuth` carrying the active
+    tenant id), then loads the tenant row to surface its ``display_name``.
+    """
+    principal = request.user
+    auth = request.auth
+    tenant = await tenants.get(item_id=auth.tenant_id)
+    return MeResponse(
+        user=MePrincipal(id=principal.id, username=principal.username),
+        tenant=MeTenant(id=str(tenant.id), display_name=tenant.display_name),
+    )

--- a/src/py/novamoc/domain/accounts/controllers/__init__.py
+++ b/src/py/novamoc/domain/accounts/controllers/__init__.py
@@ -1,0 +1,3 @@
+from ._auth import AuthController
+
+__all__ = ("AuthController",)

--- a/src/py/novamoc/domain/accounts/controllers/_auth.py
+++ b/src/py/novamoc/domain/accounts/controllers/_auth.py
@@ -1,0 +1,118 @@
+"""HTTP controller for the ``/auth`` routes (M5.10, #91).
+
+Thin wrapper around the module-level handler functions in
+``domain.accounts._handlers``: DI resolves the services / hasher /
+settings; the controller methods forward to the handlers and let the
+existing ``ProblemDetailsPlugin`` render any :class:`DomainError`
+(e.g. :class:`LoginFailedError`) as ``application/problem+json``.
+
+Service DI mirrors :class:`SchemaController` — each service is wired
+via ``providers.create_service_dependencies`` so the autocommit
+``before_send_handler`` sees the same request-scoped session.
+
+Two extra providers pull the ``PasswordHasher`` and :class:`AuthSettings`
+off ``app.state``: M5.11 stashes the hasher and the session middleware
+there at app-construction time. Keeping the resolution in DI providers
+(rather than reading ``request.app.state`` inside each method) keeps the
+handler signatures explicit about what they actually need.
+
+The controller is *not* mounted by :mod:`novamoc.asgi` in this issue;
+M5.11 owns the session-middleware wiring that makes ``/auth/login``
+functional end-to-end, and the mount lands together with that change.
+The e2e wire coverage follows in M5.12.
+"""
+
+from __future__ import annotations
+
+from advanced_alchemy.extensions.litestar import providers
+from litestar import Controller, Request, get, post
+from litestar.datastructures import (
+    State,  # noqa: TC002  # runtime DI provider annotation
+)
+from litestar.di import Provide
+from litestar.openapi.datastructures import ResponseSpec
+from litestar.status_codes import HTTP_204_NO_CONTENT
+
+# ``PasswordHasher`` and ``AuthSettings`` are runtime DI provider
+# return-type / handler-parameter annotations Litestar resolves at
+# signature parse time; the imports stay at runtime.
+from novamoc.api._problem_details import ProblemDetails
+from novamoc.config import AuthSettings  # noqa: TC001  # runtime DI annotation
+from novamoc.domain.accounts import _handlers
+from novamoc.domain.accounts._password import (
+    PasswordHasher,  # runtime DI annotation
+)
+from novamoc.domain.accounts._payloads import LoginRequest, MeResponse
+from novamoc.domain.accounts._services import (
+    TenantService,
+    UserService,
+    UserTenantMembershipService,
+)
+
+
+async def _provide_password_hasher(state: State) -> PasswordHasher:
+    """Read the shared ``PasswordHasher`` off ``app.state``.
+
+    M5.11 stashes the instance at app-construction time so per-request
+    DI doesn't re-instantiate the wrapper. The unit tests in this issue
+    set ``state.password_hasher`` directly.
+    """
+    return state.password_hasher
+
+
+async def _provide_auth_settings(state: State) -> AuthSettings:
+    """Read :class:`AuthSettings` off ``app.state.settings.auth``."""
+    return state.settings.auth
+
+
+class AuthController(Controller):
+    path = "/auth"
+    tags = ("auth",)
+
+    dependencies = (
+        {
+            "password_hasher": Provide(_provide_password_hasher),
+            "auth_settings": Provide(_provide_auth_settings),
+        }
+        | providers.create_service_dependencies(UserService, "users")
+        | providers.create_service_dependencies(
+            UserTenantMembershipService, "memberships"
+        )
+        | providers.create_service_dependencies(TenantService, "tenants")
+    )
+
+    @post(
+        "/login",
+        status_code=HTTP_204_NO_CONTENT,
+        responses={
+            401: ResponseSpec(
+                ProblemDetails,
+                description="Credentials were not accepted",
+                media_type="application/problem+json",
+            ),
+        },
+        exclude_from_auth=True,
+    )
+    async def login(
+        self,
+        request: Request,
+        data: LoginRequest,
+        users: UserService,
+        memberships: UserTenantMembershipService,
+        password_hasher: PasswordHasher,
+    ) -> None:
+        await _handlers.login(
+            request=request,
+            data=data,
+            users=users,
+            memberships=memberships,
+            password_hasher=password_hasher,
+        )
+
+    @post("/logout", status_code=HTTP_204_NO_CONTENT)
+    async def logout(self, request: Request) -> None:
+        await _handlers.logout(request=request)
+
+    @get("/me")
+    async def me(self, request: Request, tenants: TenantService) -> MeResponse:
+        return await _handlers.me(request=request, tenants=tenants)

--- a/tests/accounts/test_auth_controller.py
+++ b/tests/accounts/test_auth_controller.py
@@ -1,0 +1,44 @@
+"""Smoke tests for ``AuthController`` (M5.10, issue #91).
+
+Verifies the controller class registers cleanly on a ``Litestar`` app
+and that the three routes mount at the expected paths. The e2e wire
+coverage (real cookies, real session middleware, real bodies) lives in
+M5.12 and depends on the session middleware that lands in M5.11.
+"""
+
+from __future__ import annotations
+
+from advanced_alchemy.extensions.litestar import (
+    SQLAlchemyAsyncConfig,
+    SQLAlchemyPlugin,
+)
+from litestar import Litestar
+from litestar.datastructures import State
+
+from novamoc.config import Settings
+from novamoc.domain.accounts._password import PasswordHasher
+from novamoc.domain.accounts.controllers import AuthController
+
+
+def test_controller_registers_on_app() -> None:
+    """``AuthController`` mounts on a stock Litestar without errors."""
+    settings = Settings()
+    alchemy_config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///:memory:",
+        create_all=False,
+    )
+    app = Litestar(
+        route_handlers=[AuthController],
+        plugins=[SQLAlchemyPlugin(config=alchemy_config)],
+        state=State(
+            {
+                "settings": settings,
+                "password_hasher": PasswordHasher.from_defaults(),
+            }
+        ),
+    )
+
+    paths = {route.path for route in app.routes}
+    assert "/auth/login" in paths
+    assert "/auth/logout" in paths
+    assert "/auth/me" in paths

--- a/tests/accounts/test_handlers.py
+++ b/tests/accounts/test_handlers.py
@@ -1,0 +1,338 @@
+"""Unit tests for the auth handler functions (M5.10, issue #91).
+
+Exercises the module-level ``login`` / ``logout`` / ``me`` functions in
+``novamoc.domain.accounts._handlers`` against real account services
+backed by an in-memory engine. Anti-enumeration cases fold into one
+``LoginFailedError`` per ADR-020 / M5.6.
+
+The handlers' only Litestar touch points are
+``request.set_session`` / ``request.clear_session`` and ``request.user`` /
+``request.auth``. The session middleware that wires these to the cookie
+store lands in M5.11; the unit tests here use a tiny stand-in
+:class:`_FakeRequest` to capture session payloads and expose principal /
+auth.
+
+The auth registry tables (``users``, ``tenants``, ``user_tenant_memberships``)
+are not tenant-scoped, so the test module opts out of the autouse
+``tenant`` fixture en bloc with ``pytestmark = pytest.mark.no_tenant``.
+"""
+
+# Tests deliberately use hardcoded password literals to exercise the
+# argon2id verify path end-to-end.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from msgspec_ext import SecretStr
+
+from novamoc.domain.accounts._auth import RequestAuth
+from novamoc.domain.accounts._errors import LoginFailedError
+from novamoc.domain.accounts._handlers import login, logout, me
+from novamoc.domain.accounts._password import PasswordHasher
+from novamoc.domain.accounts._payloads import (
+    LoginRequest,
+    MePrincipal,
+    MeResponse,
+    MeTenant,
+)
+from novamoc.domain.accounts._principal import Principal
+from novamoc.domain.accounts._services import (
+    TenantService,
+    UserService,
+    UserTenantMembershipService,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from novamoc.db.models import _auth as auth_models
+
+
+pytestmark = pytest.mark.no_tenant
+
+
+# Production defaults take ~100-300 ms per hash; use the same weakened
+# parameters as ``tests/accounts/test_password.py`` so login round-trips
+# stay sub-second.
+_FAST = PasswordHasher(time_cost=1, memory_cost_kib=8192, parallelism=1)
+
+
+@dataclass
+class _FakeRequest:
+    """Minimal stand-in for ``litestar.Request`` for handler unit tests.
+
+    Captures :meth:`set_session` payloads and exposes ``user`` / ``auth``
+    attributes the real middleware would populate. Only the surface the
+    M5.10 handlers actually touch is implemented — adding fields here
+    would tie tests to implementation details.
+    """
+
+    session_payload: dict[str, Any] | None = None
+    cleared: bool = False
+    user: Principal | None = None
+    auth: RequestAuth | None = None
+    session_log: list[dict[str, Any]] = field(default_factory=list)
+
+    def set_session(self, data: dict[str, Any]) -> None:
+        self.session_payload = data
+        self.session_log.append(data)
+
+    def clear_session(self) -> None:
+        self.cleared = True
+
+
+async def _make_user(
+    session: AsyncSession,
+    username: str,
+    password: str,
+    *,
+    hasher: PasswordHasher = _FAST,
+    disabled_at: datetime | None = None,
+) -> auth_models.User:
+    svc = UserService(session=session)
+    user = await svc.create(
+        data={
+            "username": username,
+            "password_hash": hasher.hash(password),
+            "disabled_at": disabled_at,
+        },
+        auto_commit=False,
+    )
+    await session.flush()
+    return user
+
+
+async def _make_tenant(session: AsyncSession, display_name: str) -> auth_models.Tenant:
+    svc = TenantService(session=session)
+    tenant = await svc.create(
+        data={"display_name": display_name},
+        auto_commit=False,
+    )
+    await session.flush()
+    return tenant
+
+
+async def _grant_membership(
+    session: AsyncSession,
+    user: auth_models.User,
+    tenant: auth_models.Tenant,
+) -> None:
+    svc = UserTenantMembershipService(session=session)
+    await svc.create(
+        data={"user_id": user.id, "tenant_id": tenant.id},
+        auto_commit=False,
+    )
+    await session.flush()
+
+
+# ----- login ----------------------------------------------------------------
+
+
+async def test_login_happy_path_sets_session(session: AsyncSession) -> None:
+    user = await _make_user(session, "alice", "hunter2")
+    tenant = await _make_tenant(session, "Acme")
+    await _grant_membership(session, user, tenant)
+
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+
+    await login(
+        request=request,
+        data=LoginRequest(username="alice", password=SecretStr("hunter2")),
+        users=users,
+        memberships=memberships,
+        password_hasher=_FAST,
+    )
+
+    assert request.session_payload == {
+        "user_id": str(user.id),
+        "active_tenant_id": str(tenant.id),
+    }
+
+
+async def test_login_folds_username_before_lookup(session: AsyncSession) -> None:
+    """``Admin`` and ``admin`` resolve to the same row (ADR-020)."""
+    user = await _make_user(session, "admin", "hunter2")
+    tenant = await _make_tenant(session, "Acme")
+    await _grant_membership(session, user, tenant)
+
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+
+    await login(
+        request=request,
+        data=LoginRequest(username="Admin", password=SecretStr("hunter2")),
+        users=users,
+        memberships=memberships,
+        password_hasher=_FAST,
+    )
+
+    assert request.session_payload == {
+        "user_id": str(user.id),
+        "active_tenant_id": str(tenant.id),
+    }
+
+
+async def test_login_unknown_user_raises_login_failed(
+    session: AsyncSession,
+) -> None:
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="nobody", password=SecretStr("hunter2")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_FAST,
+        )
+    assert request.session_payload is None
+
+
+async def test_login_wrong_password_raises_login_failed(
+    session: AsyncSession,
+) -> None:
+    user = await _make_user(session, "alice", "correct-horse")
+    tenant = await _make_tenant(session, "Acme")
+    await _grant_membership(session, user, tenant)
+
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="alice", password=SecretStr("wrong-password")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_FAST,
+        )
+    assert request.session_payload is None
+
+
+async def test_login_disabled_user_raises_login_failed(
+    session: AsyncSession,
+) -> None:
+    user = await _make_user(
+        session,
+        "alice",
+        "hunter2",
+        disabled_at=datetime.now(tz=UTC),
+    )
+    tenant = await _make_tenant(session, "Acme")
+    await _grant_membership(session, user, tenant)
+
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="alice", password=SecretStr("hunter2")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_FAST,
+        )
+    assert request.session_payload is None
+
+
+async def test_login_zero_memberships_raises_login_failed(
+    session: AsyncSession,
+) -> None:
+    """User exists, password is correct, but has no membership row.
+
+    Folded with the other anti-enumeration cases; the M5.4 N:1 invariant
+    means this is the transient zero-membership state, not a steady-state
+    multi-membership condition.
+    """
+    await _make_user(session, "alice", "hunter2")
+
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="alice", password=SecretStr("hunter2")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_FAST,
+        )
+    assert request.session_payload is None
+
+
+async def test_login_rehashes_password_when_parameters_rotate(
+    session: AsyncSession,
+) -> None:
+    """Successful login with an out-of-date hash upgrades the stored hash.
+
+    The fixture seeds the user with the weakened ``_FAST`` parameters,
+    then the login handler runs with a stronger hasher whose
+    :meth:`check_needs_rehash` will return True.
+    """
+    user = await _make_user(session, "alice", "hunter2", hasher=_FAST)
+    tenant = await _make_tenant(session, "Acme")
+    await _grant_membership(session, user, tenant)
+    original_hash = user.password_hash
+
+    stronger = PasswordHasher(time_cost=2, memory_cost_kib=8192, parallelism=1)
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+
+    await login(
+        request=request,
+        data=LoginRequest(username="alice", password=SecretStr("hunter2")),
+        users=users,
+        memberships=memberships,
+        password_hasher=stronger,
+    )
+    await session.flush()
+
+    reloaded = await users.get(item_id=user.id)
+    assert reloaded.password_hash != original_hash
+    assert stronger.verify(reloaded.password_hash, "hunter2") is True
+
+
+# ----- logout ---------------------------------------------------------------
+
+
+async def test_logout_calls_clear_session() -> None:
+    request = _FakeRequest()
+
+    await logout(request=request)
+
+    assert request.cleared is True
+
+
+# ----- me -------------------------------------------------------------------
+
+
+async def test_me_returns_user_and_tenant(session: AsyncSession) -> None:
+    user = await _make_user(session, "alice", "hunter2")
+    tenant = await _make_tenant(session, "Acme")
+    await _grant_membership(session, user, tenant)
+
+    tenants = TenantService(session=session)
+    request = _FakeRequest(
+        user=Principal(id=str(user.id), username="alice"),
+        auth=RequestAuth(tenant_id=tenant.id),
+    )
+
+    result = await me(request=request, tenants=tenants)
+
+    assert result == MeResponse(
+        user=MePrincipal(id=str(user.id), username="alice"),
+        tenant=MeTenant(id=str(tenant.id), display_name="Acme"),
+    )


### PR DESCRIPTION
## Summary

Closes #91. Lands the HTTP surface for `/auth/login`, `/auth/logout`,
`/auth/me`:

- **Handlers** (`src/py/novamoc/domain/accounts/_handlers.py`): three
  module-level async functions (`login` / `logout` / `me`) that own
  all business logic. `login` folds every credential-rejection path
  (unknown user, wrong password, disabled user, zero-membership
  transient) into one `LoginFailedError` for anti-enumeration parity.
  Successful logins with stale hash parameters trigger a free upgrade
  via `password_hasher.check_needs_rehash`.
- **Controller** (`src/py/novamoc/domain/accounts/controllers/_auth.py`):
  thin `AuthController(Controller)` mounted at `/auth`. DI wiring
  mirrors `SchemaController` — services via
  `providers.create_service_dependencies`, plus two state-derived
  providers for `PasswordHasher` and `AuthSettings`.

Handler parameters use narrow `Protocol`s for just the slice of
`Request` they touch (`set_session` / `clear_session` / `user` / `auth`)
so unit tests run against the in-memory engine without standing up
session middleware.

## New files

- `src/py/novamoc/domain/accounts/_handlers.py`
- `src/py/novamoc/domain/accounts/controllers/__init__.py`
- `src/py/novamoc/domain/accounts/controllers/_auth.py`
- `tests/accounts/test_handlers.py` (9 unit tests covering happy path,
  username folding, every `LoginFailedError` case, rehash upgrade,
  logout, `me`)
- `tests/accounts/test_auth_controller.py` (route-registration smoke
  test)

## Non-goals (handled in follow-on issues)

- The controller is **not** mounted in `asgi.create_app` — M5.11 owns
  the session-middleware wiring and the mount lands with that change.
- No `PasswordHasher` or session-middleware stash in `app.state` yet —
  also M5.11.
- No e2e wire coverage — M5.12 depends on the session middleware from
  M5.11.

## Test plan

- [x] `uv run pytest tests/accounts/test_handlers.py` — 9 passed
- [x] `uv run pytest tests/accounts/test_auth_controller.py` — 1 passed
- [x] `just test-py` — full suite, 504 passed
- [x] `just typecheck` — `ty` clean
- [x] `just lint` + `just ratchet` — ruff ratchet matches baseline
      (no new violations)
- [x] `just format` — no changes needed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>