### PR TITLE
chore(ratchet): round coverage ratchet to nearest whole percent

### DIFF
--- a/.coverage-ratchet.json
+++ b/.coverage-ratchet.json
@@ -1,10 +1,10 @@
 {
   "js": {
-    "branch": 51.59,
-    "line": 70.91
+    "branch": 52,
+    "line": 71
   },
   "python": {
-    "branch": 83.22,
-    "line": 96.68
+    "branch": 83,
+    "line": 97
   }
 }

--- a/scripts/ratchets/coverage.py
+++ b/scripts/ratchets/coverage.py
@@ -4,6 +4,10 @@ Reads ``coverage.xml`` (Cobertura, from pytest-cov) and the vitest
 ``coverage-summary.json`` from disk, compares the four overall percentages
 against ``.coverage-ratchet.json``, and returns a ``RatchetResult``.
 
+Percentages are rounded to the nearest whole percent (e.g. 88.45 → 88,
+65.30 → 65) before comparing or writing the baseline, so a few tenths of
+a percent of noise doesn't fail CI or constantly demand a ratchet bump.
+
 The checker does **not** run the test suite — producing the artifacts is
 ``just coverage``'s job. When an artifact or the baseline is missing, the
 checker returns a ``RatchetResult`` whose ``setup_error`` tells the user
@@ -31,21 +35,24 @@ def _parse_python_coverage(path: Path) -> tuple[float, float]:
     """Return ``(line_pct, branch_pct)`` from a Cobertura ``coverage.xml``.
 
     coverage.py emits ``line-rate``/``branch-rate`` as fractions in ``[0, 1]``;
-    we expose percentages in ``[0, 100]``.
+    we expose percentages in ``[0, 100]`` rounded to the nearest whole percent.
     """
     tree = ET.parse(path)  # noqa: S314  -- our own coverage.xml, not user input
     root = tree.getroot()
     line = float(root.attrib["line-rate"]) * 100
     branch = float(root.attrib["branch-rate"]) * 100
-    return round(line, 2), round(branch, 2)
+    return float(round(line)), float(round(branch))
 
 
 def _parse_js_coverage(path: Path) -> tuple[float, float]:
-    """Return ``(line_pct, branch_pct)`` from vitest's ``coverage-summary.json``."""
+    """Return ``(line_pct, branch_pct)`` from vitest's ``coverage-summary.json``.
+
+    Percentages are rounded to the nearest whole percent before being returned.
+    """
     data = json.loads(path.read_text())
     total = data["total"]
-    line = round(float(total["lines"]["pct"]), 2)
-    branch = round(float(total["branches"]["pct"]), 2)
+    line = float(round(float(total["lines"]["pct"])))
+    branch = float(round(float(total["branches"]["pct"])))
     return line, branch
 
 

--- a/tests/scripts/test_coverage_ratchet.py
+++ b/tests/scripts/test_coverage_ratchet.py
@@ -36,21 +36,21 @@ def _baseline(
 
 
 def test_parse_python_coverage_xml() -> None:
+    # 88.45 -> 88, 76.12 -> 76 after rounding to nearest whole percent.
     line, branch = cov_ratchet._parse_python_coverage(CLEAN_XML)
-    assert line == pytest.approx(88.45)
-    assert branch == pytest.approx(76.12)
+    assert line == pytest.approx(88)
+    assert branch == pytest.approx(76)
 
 
 def test_parse_js_coverage_summary() -> None:
+    # 65.30 -> 65, 58.10 -> 58 after rounding to nearest whole percent.
     line, branch = cov_ratchet._parse_js_coverage(CLEAN_JSON)
-    assert line == pytest.approx(65.30)
-    assert branch == pytest.approx(58.10)
+    assert line == pytest.approx(65)
+    assert branch == pytest.approx(58)
 
 
 def test_check_clean_returns_no_changes(tmp_path: Path) -> None:
-    baseline = _baseline(
-        tmp_path, py_line=88.45, py_branch=76.12, js_line=65.30, js_branch=58.10
-    )
+    baseline = _baseline(tmp_path, py_line=88, py_branch=76, js_line=65, js_branch=58)
     result = cov_ratchet.check(
         baseline_path=baseline,
         coverage_xml=CLEAN_XML,
@@ -63,10 +63,8 @@ def test_check_clean_returns_no_changes(tmp_path: Path) -> None:
 
 
 def test_check_regression_when_python_line_drops(tmp_path: Path) -> None:
-    # Baseline higher than fixture's 88.45 -> python.line is a regression.
-    baseline = _baseline(
-        tmp_path, py_line=90.00, py_branch=76.12, js_line=65.30, js_branch=58.10
-    )
+    # Baseline higher than fixture's rounded 88 -> python.line is a regression.
+    baseline = _baseline(tmp_path, py_line=90, py_branch=76, js_line=65, js_branch=58)
     result = cov_ratchet.check(
         baseline_path=baseline,
         coverage_xml=CLEAN_XML,
@@ -75,15 +73,13 @@ def test_check_regression_when_python_line_drops(tmp_path: Path) -> None:
     metrics = {c.metric for c in result.regressions}
     assert metrics == {"python.line"}
     [change] = result.regressions
-    assert change.old == pytest.approx(90.00)
-    assert change.new == pytest.approx(88.45)
+    assert change.old == pytest.approx(90)
+    assert change.new == pytest.approx(88)
 
 
 def test_check_improvement_when_js_branch_rises(tmp_path: Path) -> None:
-    # Baseline lower than fixture's 58.10 -> js.branch is an improvement.
-    baseline = _baseline(
-        tmp_path, py_line=88.45, py_branch=76.12, js_line=65.30, js_branch=55.00
-    )
+    # Baseline lower than fixture's rounded 58 -> js.branch is an improvement.
+    baseline = _baseline(tmp_path, py_line=88, py_branch=76, js_line=65, js_branch=55)
     result = cov_ratchet.check(
         baseline_path=baseline,
         coverage_xml=CLEAN_XML,
@@ -137,8 +133,8 @@ def test_update_writes_current_values(tmp_path: Path) -> None:
     assert result.setup_error is None
     written = json.loads(baseline.read_text())
     assert written == {
-        "python": {"line": pytest.approx(88.45), "branch": pytest.approx(76.12)},
-        "js": {"line": pytest.approx(65.30), "branch": pytest.approx(58.10)},
+        "python": {"line": pytest.approx(88), "branch": pytest.approx(76)},
+        "js": {"line": pytest.approx(65), "branch": pytest.approx(58)},
     }
 
 


### PR DESCRIPTION
## Summary

- Coverage ratchet now rounds the four percentages to the nearest whole percent before comparing against the baseline. A few tenths of a percent of measurement noise no longer fail CI or demand a baseline bump.
- Baseline shifts: `python.line` 96.68→97, `python.branch` 83.22→83, `js.line` 70.91→71, `js.branch` 51.59→52.
- Implemented as `round()` inside `_parse_python_coverage` / `_parse_js_coverage` so both the write-baseline and compare paths see identical integer values; `.coverage-ratchet.json` is human-readable integers instead of two-decimal floats.

## Test plan

- [x] `uv run pytest tests/scripts/test_coverage_ratchet.py` — 10 passed (fixture assertions updated to expect rounded integers; regression/improvement tests still trigger by stepping baseline ±2 around the rounded fixture).
- [x] `uv run pytest` — full Python suite, 494 passed.
- [x] `uv run ruff check scripts/ratchets/coverage.py tests/scripts/test_coverage_ratchet.py` — clean.
- [x] `uv run ty check scripts/ratchets/coverage.py` — clean.
- [ ] CI `just check` on the PR (includes JS coverage which isn't installed in the bridge worktree locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)