### PR TITLE
test(events): hoist EventServiceBundle into a shared fixture

### DIFF
--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for ``tests/events/``.
+
+The ``event_services`` fixture wires an ``EventServiceBundle`` against
+the function-scoped ``session`` from the top-level conftest. The bundle
+shape is fixed by the production wiring (``domain.events._bundle``);
+the only knob worth varying per test is ``schema_version``, which
+defaults to ``0`` here — handler-level tests don't exercise the
+schema-version gate (that's the controller's job), so ``0`` matches
+what every consumer in this directory wants.
+
+``tests/events/test_bundle.py`` keeps its own fixture because it
+substitutes a counting spy for ``AssetTypeFieldService``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from novamoc.domain.events._bundle import EventServiceBundle
+from novamoc.domain.events.services import EventLogService
+from novamoc.domain.schema.services import (
+    AssetTypeFieldService,
+    MaintenanceRecordTypeFieldService,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture
+def event_services(session: AsyncSession) -> EventServiceBundle:
+    return EventServiceBundle(
+        asset_type_field_service=AssetTypeFieldService(session=session),
+        maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
+            session=session
+        ),
+        event_log_service=EventLogService(session=session),
+        schema_version=0,
+    )

--- a/tests/events/test_catchup_cross_tenant_isolation.py
+++ b/tests/events/test_catchup_cross_tenant_isolation.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from novamoc.db._tenant_context import use_tenant
-from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._pagination import EventLogCursorPaginator
 from novamoc.domain.events._payloads import (
     Created,
@@ -22,10 +21,6 @@ from novamoc.domain.events._payloads import (
     EventEnvelope,
 )
 from novamoc.domain.events.services import EventLogService
-from novamoc.domain.schema.services import (
-    AssetTypeFieldService,
-    MaintenanceRecordTypeFieldService,
-)
 from tests._constants import DEV_TENANT_ID_A, DEV_TENANT_ID_B
 from tests.data.scenarios import ACTIVE_TRUCK
 
@@ -35,16 +30,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
-
-def _bundle(session: AsyncSession) -> EventServiceBundle:
-    return EventServiceBundle(
-        asset_type_field_service=AssetTypeFieldService(session=session),
-        maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
-            session=session
-        ),
-        event_log_service=EventLogService(session=session),
-        schema_version=0,
-    )
+    from novamoc.domain.events._bundle import EventServiceBundle
 
 
 async def _append(bundle: EventServiceBundle, hlc: str, type_id: UUID) -> None:
@@ -61,11 +47,10 @@ async def _append(bundle: EventServiceBundle, hlc: str, type_id: UUID) -> None:
 
 async def test_paginator_isolates_tenants_at_interleaved_seqs(
     session: AsyncSession,
+    event_services: EventServiceBundle,
     seed: Callable[..., Awaitable[Mapping[str, Mapping[str, UUID]]]],
 ) -> None:
     """Interleaved append under two tenants — each tenant sees only its own."""
-    bundle = _bundle(session)
-
     # Seed an ``asset_type`` row per tenant so the assets-projection FK
     # constraint (``foreign_keys=ON``) is satisfied when the Created events
     # fold into ``assets``. Same fixture UUID in both tenants — the
@@ -80,15 +65,15 @@ async def test_paginator_isolates_tenants_at_interleaved_seqs(
 
     # Interleave: t-a, t-b, t-a, t-b, t-a → three events for t-a, two for t-b.
     with use_tenant(DEV_TENANT_ID_A):
-        await _append(bundle, "0001700000000001-00000-aaa", type_id_a)
+        await _append(event_services, "0001700000000001-00000-aaa", type_id_a)
     with use_tenant(DEV_TENANT_ID_B):
-        await _append(bundle, "0001700000000002-00000-bbb", type_id_b)
+        await _append(event_services, "0001700000000002-00000-bbb", type_id_b)
     with use_tenant(DEV_TENANT_ID_A):
-        await _append(bundle, "0001700000000003-00000-aaa", type_id_a)
+        await _append(event_services, "0001700000000003-00000-aaa", type_id_a)
     with use_tenant(DEV_TENANT_ID_B):
-        await _append(bundle, "0001700000000004-00000-bbb", type_id_b)
+        await _append(event_services, "0001700000000004-00000-bbb", type_id_b)
     with use_tenant(DEV_TENANT_ID_A):
-        await _append(bundle, "0001700000000005-00000-aaa", type_id_a)
+        await _append(event_services, "0001700000000005-00000-aaa", type_id_a)
 
     paginator = EventLogCursorPaginator(EventLogService(session=session))
 

--- a/tests/events/test_event_log_type_id.py
+++ b/tests/events/test_event_log_type_id.py
@@ -8,16 +8,10 @@ from uuid import uuid4
 from sqlalchemy import select
 
 from novamoc.db.models.data import EventLog
-from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._payloads import (
     Created,
     EntityFamily,
     EventEnvelope,
-)
-from novamoc.domain.events.services import EventLogService
-from novamoc.domain.schema.services import (
-    AssetTypeFieldService,
-    MaintenanceRecordTypeFieldService,
 )
 from tests.data.scenarios import ACTIVE_TRUCK
 
@@ -27,26 +21,20 @@ if TYPE_CHECKING:
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from novamoc.domain.events._bundle import EventServiceBundle
     from tests.data.scenarios import Scenario
 
 
 async def test_append_event_persists_type_id(
     session: AsyncSession,
+    event_services: EventServiceBundle,
     seed: Callable[[Scenario], Awaitable[Mapping[str, Mapping[str, UUID]]]],
 ) -> None:
     ids = await seed(ACTIVE_TRUCK)
     type_id = ids["asset_type"]["Truck"]
     instance_id = uuid4()
-    bundle = EventServiceBundle(
-        asset_type_field_service=AssetTypeFieldService(session=session),
-        maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
-            session=session
-        ),
-        event_log_service=EventLogService(session=session),
-        schema_version=0,
-    )
 
-    await bundle.append_event(
+    await event_services.append_event(
         EventEnvelope(
             hlc="0001700000000000-00000-abc",
             family=EntityFamily.ASSET,

--- a/tests/events/test_handlers_asset.py
+++ b/tests/events/test_handlers_asset.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import pytest
 
 from novamoc.domain.accounts import RequestAuth
-from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._errors import (
     UnknownFieldError,
     ValueTypeMismatchError,
@@ -22,11 +21,6 @@ from novamoc.domain.events._payloads import (
     EventEnvelope,
     Updated,
 )
-from novamoc.domain.events.services import EventLogService
-from novamoc.domain.schema.services import (
-    AssetTypeFieldService,
-    MaintenanceRecordTypeFieldService,
-)
 from tests._constants import DEV_TENANT_ID
 from tests.data.scenarios import (
     ACTIVE_TRUCK_WITH_VIN_FIELD,
@@ -37,7 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
     from uuid import UUID
 
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from novamoc.domain.events._bundle import EventServiceBundle
 
 
 _HLC = "0000000000000001-00000-client-a"
@@ -45,18 +39,6 @@ _HLC = "0000000000000001-00000-client-a"
 
 def _auth() -> RequestAuth:
     return RequestAuth(tenant_id=DEV_TENANT_ID)
-
-
-@pytest.fixture
-def event_services(session: AsyncSession) -> EventServiceBundle:
-    return EventServiceBundle(
-        asset_type_field_service=AssetTypeFieldService(session=session),
-        maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
-            session=session
-        ),
-        event_log_service=EventLogService(session=session),
-        schema_version=0,
-    )
 
 
 def _envelope(

--- a/tests/events/test_handlers_maintenance_record.py
+++ b/tests/events/test_handlers_maintenance_record.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import pytest
 
 from novamoc.domain.accounts import RequestAuth
-from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._errors import (
     UnknownFieldError,
     ValueTypeMismatchError,
@@ -23,11 +22,6 @@ from novamoc.domain.events._payloads import (
     Parent,
     Updated,
 )
-from novamoc.domain.events.services import EventLogService
-from novamoc.domain.schema.services import (
-    AssetTypeFieldService,
-    MaintenanceRecordTypeFieldService,
-)
 from tests._constants import DEV_TENANT_ID
 from tests.data.scenarios import (
     ACTIVE_OIL_CHANGE_WITH_NOTES,
@@ -39,7 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
     from uuid import UUID
 
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from novamoc.domain.events._bundle import EventServiceBundle
 
 
 _HLC = "0000000000000001-00000-client-a"
@@ -47,18 +41,6 @@ _HLC = "0000000000000001-00000-client-a"
 
 def _auth() -> RequestAuth:
     return RequestAuth(tenant_id=DEV_TENANT_ID)
-
-
-@pytest.fixture
-def event_services(session: AsyncSession) -> EventServiceBundle:
-    return EventServiceBundle(
-        asset_type_field_service=AssetTypeFieldService(session=session),
-        maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
-            session=session
-        ),
-        event_log_service=EventLogService(session=session),
-        schema_version=0,
-    )
 
 
 def _envelope(

--- a/tests/events/test_pagination.py
+++ b/tests/events/test_pagination.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 import pytest
 
-from novamoc.domain.events._bundle import EventServiceBundle
 from novamoc.domain.events._pagination import EventLogCursorPaginator
 from novamoc.domain.events._payloads import (
     Created,
@@ -16,10 +15,6 @@ from novamoc.domain.events._payloads import (
     RecordedEvent,
 )
 from novamoc.domain.events.services import EventLogService
-from novamoc.domain.schema.services import (
-    AssetTypeFieldService,
-    MaintenanceRecordTypeFieldService,
-)
 from tests.data.scenarios import ACTIVE_TRUCK
 
 if TYPE_CHECKING:
@@ -28,6 +23,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from novamoc.domain.events._bundle import EventServiceBundle
     from tests.data.scenarios import Scenario
 
 
@@ -50,18 +46,6 @@ def paginator(session: AsyncSession) -> EventLogCursorPaginator:
     return EventLogCursorPaginator(EventLogService(session=session))
 
 
-@pytest.fixture
-def bundle(session: AsyncSession) -> EventServiceBundle:
-    return EventServiceBundle(
-        asset_type_field_service=AssetTypeFieldService(session=session),
-        maintenance_record_type_field_service=MaintenanceRecordTypeFieldService(
-            session=session
-        ),
-        event_log_service=EventLogService(session=session),
-        schema_version=0,
-    )
-
-
 async def test_get_items_empty_stream_returns_no_items_and_no_cursor(
     paginator: EventLogCursorPaginator,
 ) -> None:
@@ -72,11 +56,11 @@ async def test_get_items_empty_stream_returns_no_items_and_no_cursor(
 
 async def test_get_items_returns_all_when_under_page_size(
     paginator: EventLogCursorPaginator,
-    bundle: EventServiceBundle,
+    event_services: EventServiceBundle,
     seed: Callable[[Scenario], Awaitable[Mapping[str, Mapping[str, UUID]]]],
 ) -> None:
     type_id = (await seed(ACTIVE_TRUCK))["asset_type"]["Truck"]
-    await _append_n(bundle, 3, type_id)
+    await _append_n(event_services, 3, type_id)
     items, cursor = await paginator.get_items(cursor=None, results_per_page=10)
     assert len(items) == 3
     assert all(isinstance(it, RecordedEvent) for it in items)
@@ -86,11 +70,11 @@ async def test_get_items_returns_all_when_under_page_size(
 
 async def test_get_items_returns_first_page_and_signals_more(
     paginator: EventLogCursorPaginator,
-    bundle: EventServiceBundle,
+    event_services: EventServiceBundle,
     seed: Callable[[Scenario], Awaitable[Mapping[str, Mapping[str, UUID]]]],
 ) -> None:
     type_id = (await seed(ACTIVE_TRUCK))["asset_type"]["Truck"]
-    await _append_n(bundle, 5, type_id)
+    await _append_n(event_services, 5, type_id)
     items, cursor = await paginator.get_items(cursor=None, results_per_page=2)
     assert len(items) == 2
     assert cursor == items[-1].seq
@@ -98,11 +82,11 @@ async def test_get_items_returns_first_page_and_signals_more(
 
 async def test_get_items_cursor_handoff_continues_stream(
     paginator: EventLogCursorPaginator,
-    bundle: EventServiceBundle,
+    event_services: EventServiceBundle,
     seed: Callable[[Scenario], Awaitable[Mapping[str, Mapping[str, UUID]]]],
 ) -> None:
     type_id = (await seed(ACTIVE_TRUCK))["asset_type"]["Truck"]
-    await _append_n(bundle, 5, type_id)
+    await _append_n(event_services, 5, type_id)
     page1, cursor1 = await paginator.get_items(cursor=None, results_per_page=2)
     page2, cursor2 = await paginator.get_items(cursor=cursor1, results_per_page=2)
     page3, cursor3 = await paginator.get_items(cursor=cursor2, results_per_page=2)
@@ -119,11 +103,11 @@ async def test_get_items_cursor_handoff_continues_stream(
 
 async def test_get_items_exact_page_boundary_signals_caught_up(
     paginator: EventLogCursorPaginator,
-    bundle: EventServiceBundle,
+    event_services: EventServiceBundle,
     seed: Callable[[Scenario], Awaitable[Mapping[str, Mapping[str, UUID]]]],
 ) -> None:
     type_id = (await seed(ACTIVE_TRUCK))["asset_type"]["Truck"]
-    await _append_n(bundle, 4, type_id)
+    await _append_n(event_services, 4, type_id)
     items, cursor = await paginator.get_items(cursor=None, results_per_page=4)
     assert len(items) == 4
     assert cursor is None  # the +1 fetch returned only 4, so we're done


### PR DESCRIPTION
## Summary

Stacked on #129. Five files under `tests/events/` each rebuild the same `EventServiceBundle` inline; three of them already wrap it in a local fixture (`event_services`, `bundle`, `_bundle`). Hoist the construction into a new `tests/events/conftest.py` under the canonical name `event_services` (matching the top-level `services` fixture) and delete the local copies.

**Net change:** +62 / −100 LOC.

Consumers updated:
- `test_handlers_asset.py`, `test_handlers_maintenance_record.py`: drop the local `event_services` fixture.
- `test_pagination.py`: drop the local `bundle` fixture; rename test parameters from `bundle` to `event_services`. The `_append_n(bundle, ...)` helper keeps `bundle` as its own arg name.
- `test_catchup_cross_tenant_isolation.py`: drop the `_bundle()` factory; take `event_services` as a fixture parameter.
- `test_event_log_type_id.py`: take `event_services` instead of constructing inline.

`tests/events/test_bundle.py` keeps its local fixture because it substitutes a counting spy for `AssetTypeFieldService` — the only consumer that genuinely needs a different bundle.

Note: this PR's scope is narrower than the original review proposed. The db-layer helpers `_seed_two_tenants` and `_enable_foreign_keys` are each used in exactly one test file — that's not duplication, so no `tests/db/conftest.py` is needed.

## Test plan

- [x] `uv run pytest tests/events` → 159 passed
- [x] `uv run pytest` → 529 passed (unchanged from PR 1 baseline)
- [x] `just lint` / `just format` / `ty check` clean