### PR TITLE
test(events): consolidate _event dict-builder into _http_helpers

### DIFF
--- a/tests/events/_http_helpers.py
+++ b/tests/events/_http_helpers.py
@@ -5,6 +5,12 @@ End-to-end tests for ``POST /events`` need referent ``asset_types`` /
 the entity tables under ``PRAGMA foreign_keys=ON``. Rather than push
 that boilerplate into every test, these helpers wrap the
 ``POST /schema`` calls each test pattern needs.
+
+``event_envelope`` builds the wire-shape ``EventEnvelope`` dict for
+``POST /events`` requests. Callers fill in only the fields that matter
+to the test under hand — the defaults are a minimal-valid asset
+``created`` event so shape-agnostic tests (drift, idempotency, schema
+version) don't have to spell the body out.
 """
 
 from __future__ import annotations
@@ -13,7 +19,12 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from litestar.testing import AsyncTestClient
+
+
+DEFAULT_HLC = "0000000000000001-00000-client-a"
 
 
 async def create_asset_type(client: AsyncTestClient) -> tuple[str, int]:
@@ -84,4 +95,72 @@ async def create_asset(
     return instance_id
 
 
-__all__ = ("create_asset", "create_asset_type", "create_mr_type")
+async def seed_asset_type_with_field(
+    client: AsyncTestClient, *, field_data_type: str = "text"
+) -> tuple[str, str, int]:
+    """Create an ``asset_type`` and one user field via ``POST /schema``.
+
+    Returns ``(type_id, field_id, schema_version)``.
+    """
+    type_id = str(uuid4())
+    field_id = str(uuid4())
+    resp = await client.post(
+        "/schema",
+        json={
+            "type": "create_asset_type",
+            "entity_id": type_id,
+            "payload": {"name": f"Truck-{type_id[:8]}"},
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+    resp = await client.post(
+        "/schema",
+        json={
+            "type": "create_asset_type_field",
+            "entity_id": field_id,
+            "payload": {
+                "parent_id": type_id,
+                "name": "vin",
+                "data_type": field_data_type,
+            },
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return type_id, field_id, int(resp.json()["schema_version"])
+
+
+def event_envelope(
+    *,
+    type_id: str | None = None,
+    hlc: str = DEFAULT_HLC,
+    instance_id: str | None = None,
+    values: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Wire-shape ``EventEnvelope`` dict for ``POST /events`` request bodies.
+
+    Builds a minimal-valid ``asset`` family ``created`` event. ``values``
+    defaults to ``{"col:name": "x"}`` so shape-agnostic tests (drift,
+    idempotency, schema version) need not spell the body out. Tests that
+    target other families or event types build the dict inline.
+    """
+    return {
+        "hlc": hlc,
+        "family": "asset",
+        "type_id": type_id or str(uuid4()),
+        "instance_id": instance_id or str(uuid4()),
+        "body": {
+            "event": "created",
+            "values": dict(values) if values is not None else {"col:name": "x"},
+        },
+    }
+
+
+__all__ = (
+    "DEFAULT_HLC",
+    "create_asset",
+    "create_asset_type",
+    "create_mr_type",
+    "event_envelope",
+    "seed_asset_type_with_field",
+)

--- a/tests/events/test_endpoint_drift.py
+++ b/tests/events/test_endpoint_drift.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import pytest
 
@@ -14,7 +13,7 @@ from novamoc.config import (
     ServerSettings,
     Settings,
 )
-from tests.events._http_helpers import create_asset_type
+from tests.events._http_helpers import create_asset_type, event_envelope
 
 if TYPE_CHECKING:
     from litestar.testing import AsyncTestClient
@@ -22,16 +21,6 @@ if TYPE_CHECKING:
 
 _PAST_HLC = "0000000000000001-00000-client-a"
 _FAR_FUTURE_HLC = "9999999999999999-00000-client-a"
-
-
-def _event(hlc: str, *, type_id: str | None = None) -> dict[str, object]:
-    return {
-        "hlc": hlc,
-        "family": "asset",
-        "type_id": type_id or str(uuid4()),
-        "instance_id": str(uuid4()),
-        "body": {"event": "created", "values": {"col:name": "x"}},
-    }
 
 
 @pytest.fixture
@@ -63,7 +52,7 @@ async def test_past_hlc_is_accepted(client: AsyncTestClient) -> None:
         "/events",
         json={
             "schema_version": schema_version,
-            "events": [_event(_PAST_HLC, type_id=type_id)],
+            "events": [event_envelope(hlc=_PAST_HLC, type_id=type_id)],
         },
     )
     assert resp.status_code == 202, resp.text
@@ -78,7 +67,7 @@ async def test_far_future_hlc_yields_rejected_outcome(
     # batch HTTP envelope still returns 202.
     resp = await client.post(
         "/events",
-        json={"schema_version": 0, "events": [_event(_FAR_FUTURE_HLC)]},
+        json={"schema_version": 0, "events": [event_envelope(hlc=_FAR_FUTURE_HLC)]},
     )
     assert resp.status_code == 202, resp.text
     body = resp.json()
@@ -101,7 +90,7 @@ async def test_malformed_hlc_yields_rejected_invalid_payload_shape(
 ) -> None:
     resp = await client.post(
         "/events",
-        json={"schema_version": 0, "events": [_event("not-an-hlc")]},
+        json={"schema_version": 0, "events": [event_envelope(hlc="not-an-hlc")]},
     )
     assert resp.status_code == 202, resp.text
     body = resp.json()
@@ -127,9 +116,9 @@ async def test_mixed_batch_records_each_event_independently(
         json={
             "schema_version": schema_version,
             "events": [
-                _event(_PAST_HLC, type_id=type_id),
-                _event(_FAR_FUTURE_HLC, type_id=type_id),
-                _event("0000000000000002-00000-client-a", type_id=type_id),
+                event_envelope(hlc=_PAST_HLC, type_id=type_id),
+                event_envelope(hlc=_FAR_FUTURE_HLC, type_id=type_id),
+                event_envelope(hlc="0000000000000002-00000-client-a", type_id=type_id),
             ],
         },
     )

--- a/tests/events/test_endpoint_idempotency.py
+++ b/tests/events/test_endpoint_idempotency.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from tests.events._http_helpers import create_asset_type
+from tests.events._http_helpers import create_asset_type, event_envelope
 
 if TYPE_CHECKING:
     from litestar.testing import AsyncTestClient
@@ -22,18 +22,6 @@ _HLC_A = "0000000000000001-00000-client-a"
 _HLC_B = "0000000000000002-00000-client-a"
 
 
-def _event(
-    hlc: str, *, type_id: str, instance_id: str | None = None
-) -> dict[str, object]:
-    return {
-        "hlc": hlc,
-        "family": "asset",
-        "type_id": type_id,
-        "instance_id": instance_id or str(uuid4()),
-        "body": {"event": "created", "values": {"col:name": "x"}},
-    }
-
-
 async def test_fresh_batch_returns_all_accepted(client: AsyncTestClient) -> None:
     type_id, schema_version = await create_asset_type(client)
     resp = await client.post(
@@ -41,8 +29,8 @@ async def test_fresh_batch_returns_all_accepted(client: AsyncTestClient) -> None
         json={
             "schema_version": schema_version,
             "events": [
-                _event(_HLC_A, type_id=type_id),
-                _event(_HLC_B, type_id=type_id),
+                event_envelope(hlc=_HLC_A, type_id=type_id),
+                event_envelope(hlc=_HLC_B, type_id=type_id),
             ],
         },
     )
@@ -58,8 +46,8 @@ async def test_replay_same_batch_returns_all_duplicate(
     body = {
         "schema_version": schema_version,
         "events": [
-            _event(_HLC_A, type_id=type_id),
-            _event(_HLC_B, type_id=type_id),
+            event_envelope(hlc=_HLC_A, type_id=type_id),
+            event_envelope(hlc=_HLC_B, type_id=type_id),
         ],
     }
     first = await client.post("/events", json=body)
@@ -77,7 +65,7 @@ async def test_partial_replay_returns_mixed_outcomes(client: AsyncTestClient) ->
         "/events",
         json={
             "schema_version": schema_version,
-            "events": [_event(_HLC_A, type_id=type_id)],
+            "events": [event_envelope(hlc=_HLC_A, type_id=type_id)],
         },
     )
     assert first.status_code == 202, first.text
@@ -87,8 +75,8 @@ async def test_partial_replay_returns_mixed_outcomes(client: AsyncTestClient) ->
         json={
             "schema_version": schema_version,
             "events": [
-                _event(_HLC_A, type_id=type_id),
-                _event(_HLC_B, type_id=type_id),
+                event_envelope(hlc=_HLC_A, type_id=type_id),
+                event_envelope(hlc=_HLC_B, type_id=type_id),
             ],
         },
     )
@@ -122,7 +110,7 @@ async def test_rejection_does_not_consume_an_hlc(client: AsyncTestClient) -> Non
         "/events",
         json={
             "schema_version": schema_version,
-            "events": [_event(_HLC_A, type_id=type_id)],
+            "events": [event_envelope(hlc=_HLC_A, type_id=type_id)],
         },
     )
     assert second.status_code == 202, second.text

--- a/tests/events/test_endpoint_schema_version.py
+++ b/tests/events/test_endpoint_schema_version.py
@@ -11,21 +11,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from tests.events._http_helpers import event_envelope
+
 if TYPE_CHECKING:
     from litestar.testing import AsyncTestClient
-
-
-_VALID_HLC = "0000000000000001-00000-client-a"
-
-
-def _event(hlc: str = _VALID_HLC, *, type_id: str | None = None) -> dict[str, object]:
-    return {
-        "hlc": hlc,
-        "family": "asset",
-        "type_id": type_id or str(uuid4()),
-        "instance_id": str(uuid4()),
-        "body": {"event": "created", "values": {"col:name": "x"}},
-    }
 
 
 async def _bump_schema_version(client: AsyncTestClient) -> tuple[str, int]:
@@ -65,7 +54,7 @@ async def test_stale_version_rejected_as_409(client: AsyncTestClient) -> None:
 
     resp = await client.post(
         "/events",
-        json={"schema_version": 0, "events": [_event()]},
+        json={"schema_version": 0, "events": [event_envelope()]},
     )
     assert resp.status_code == 409, resp.text
     body = resp.json()
@@ -79,7 +68,7 @@ async def test_stale_version_rejected_as_409(client: AsyncTestClient) -> None:
 async def test_future_version_also_rejected(client: AsyncTestClient) -> None:
     resp = await client.post(
         "/events",
-        json={"schema_version": 99, "events": [_event()]},
+        json={"schema_version": 99, "events": [event_envelope()]},
     )
     assert resp.status_code == 409, resp.text
     body = resp.json()
@@ -96,7 +85,7 @@ async def test_matched_version_after_schema_change_is_accepted(
         "/events",
         json={
             "schema_version": version_after_create,
-            "events": [_event(type_id=type_id)],
+            "events": [event_envelope(type_id=type_id)],
         },
     )
     assert resp.status_code == 202, resp.text
@@ -112,7 +101,7 @@ async def test_version_gate_runs_before_hlc_validation(
     _ = await _bump_schema_version(client)
     resp = await client.post(
         "/events",
-        json={"schema_version": 0, "events": [_event("not-an-hlc")]},
+        json={"schema_version": 0, "events": [event_envelope(hlc="not-an-hlc")]},
     )
     assert resp.status_code == 409, resp.text
     assert resp.json()["type"] == "http://test/problems/schema_version_stale.html"

--- a/tests/events/test_endpoint_validation.py
+++ b/tests/events/test_endpoint_validation.py
@@ -11,60 +11,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from tests.events._http_helpers import (
+    DEFAULT_HLC,
+    event_envelope,
+    seed_asset_type_with_field,
+)
+
 if TYPE_CHECKING:
     from litestar.testing import AsyncTestClient
-
-
-_VALID_HLC = "0000000000000001-00000-client-a"
-
-
-async def _seed_asset_type_with_field(
-    client: AsyncTestClient,
-    *,
-    field_data_type: str = "text",
-) -> tuple[str, str, int]:
-    type_id = str(uuid4())
-    field_id = str(uuid4())
-    resp = await client.post(
-        "/schema",
-        json={
-            "type": "create_asset_type",
-            "entity_id": type_id,
-            "payload": {"name": f"Truck-{type_id[:8]}"},
-        },
-    )
-    assert resp.status_code in (200, 201), resp.text
-
-    resp = await client.post(
-        "/schema",
-        json={
-            "type": "create_asset_type_field",
-            "entity_id": field_id,
-            "payload": {
-                "parent_id": type_id,
-                "name": "vin",
-                "data_type": field_data_type,
-            },
-        },
-    )
-    assert resp.status_code in (200, 201), resp.text
-    schema_version = int(resp.json()["schema_version"])
-    return type_id, field_id, schema_version
-
-
-def _event(
-    *,
-    type_id: str,
-    values: dict[str, object],
-    instance_id: str | None = None,
-) -> dict[str, object]:
-    return {
-        "hlc": _VALID_HLC,
-        "family": "asset",
-        "type_id": type_id,
-        "instance_id": instance_id or str(uuid4()),
-        "body": {"event": "created", "values": values},
-    }
 
 
 async def _post_one(
@@ -83,11 +37,11 @@ async def _post_one(
 async def test_known_user_field_with_correct_type_is_accepted(
     client: AsyncTestClient,
 ) -> None:
-    type_id, field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, field_id, schema_version = await seed_asset_type_with_field(client)
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={field_id: "ABC123"}),
+        event_envelope(type_id=type_id, values={field_id: "ABC123"}),
     )
     assert outcome["outcome"] == "accepted"
 
@@ -95,12 +49,12 @@ async def test_known_user_field_with_correct_type_is_accepted(
 async def test_unknown_user_field_rejects_unknown_field(
     client: AsyncTestClient,
 ) -> None:
-    type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, _field_id, schema_version = await seed_asset_type_with_field(client)
     bogus_field_id = str(uuid4())
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={bogus_field_id: "x"}),
+        event_envelope(type_id=type_id, values={bogus_field_id: "x"}),
     )
     assert outcome["outcome"] == "rejected:unknown_field"
     # The exception's extras must reach the wire — without them clients
@@ -116,7 +70,7 @@ async def test_unknown_user_field_rejects_unknown_field(
 async def test_field_under_different_type_reported_as_unknown(
     client: AsyncTestClient,
 ) -> None:
-    _type_id_a, field_id, schema_version_a = await _seed_asset_type_with_field(client)
+    _type_id_a, field_id, schema_version_a = await seed_asset_type_with_field(client)
     type_id_b = str(uuid4())
     resp = await client.post(
         "/schema",
@@ -133,13 +87,13 @@ async def test_field_under_different_type_reported_as_unknown(
     outcome = await _post_one(
         client,
         schema_version_b,
-        _event(type_id=type_id_b, values={field_id: "x"}),
+        event_envelope(type_id=type_id_b, values={field_id: "x"}),
     )
     assert outcome["outcome"] == "rejected:unknown_field"
 
 
 async def test_deactivated_field_is_still_accepted(client: AsyncTestClient) -> None:
-    type_id, field_id, _ = await _seed_asset_type_with_field(client)
+    type_id, field_id, _ = await seed_asset_type_with_field(client)
     resp = await client.post(
         "/schema",
         json={
@@ -153,19 +107,19 @@ async def test_deactivated_field_is_still_accepted(client: AsyncTestClient) -> N
     outcome = await _post_one(
         client,
         schema_version_after_deactivate,
-        _event(type_id=type_id, values={field_id: "still works"}),
+        event_envelope(type_id=type_id, values={field_id: "still works"}),
     )
     assert outcome["outcome"] == "accepted"
 
 
 async def test_value_type_mismatch_rejects_with_code(client: AsyncTestClient) -> None:
-    type_id, field_id, schema_version = await _seed_asset_type_with_field(
+    type_id, field_id, schema_version = await seed_asset_type_with_field(
         client, field_data_type="integer"
     )
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={field_id: "not-a-number"}),
+        event_envelope(type_id=type_id, values={field_id: "not-a-number"}),
     )
     assert outcome["outcome"] == "rejected:value_type_mismatch"
     problem = outcome["problem"]
@@ -177,7 +131,7 @@ async def test_value_type_mismatch_rejects_with_code(client: AsyncTestClient) ->
 
 
 async def test_null_value_is_always_accepted(client: AsyncTestClient) -> None:
-    type_id, field_id, schema_version = await _seed_asset_type_with_field(
+    type_id, field_id, schema_version = await seed_asset_type_with_field(
         client, field_data_type="integer"
     )
     # Updated has no row-state component, so the asset row must exist
@@ -205,7 +159,7 @@ async def test_null_value_is_always_accepted(client: AsyncTestClient) -> None:
         client,
         schema_version,
         {
-            "hlc": _VALID_HLC,
+            "hlc": DEFAULT_HLC,
             "family": "asset",
             "type_id": type_id,
             "instance_id": instance_id,
@@ -216,41 +170,41 @@ async def test_null_value_is_always_accepted(client: AsyncTestClient) -> None:
 
 
 async def test_col_name_accepts_text(client: AsyncTestClient) -> None:
-    type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, _field_id, schema_version = await seed_asset_type_with_field(client)
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={"col:name": "Truck-7"}),
+        event_envelope(type_id=type_id, values={"col:name": "Truck-7"}),
     )
     assert outcome["outcome"] == "accepted"
 
 
 async def test_col_name_rejects_wrong_type(client: AsyncTestClient) -> None:
-    type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, _field_id, schema_version = await seed_asset_type_with_field(client)
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={"col:name": 42}),
+        event_envelope(type_id=type_id, values={"col:name": 42}),
     )
     assert outcome["outcome"] == "rejected:value_type_mismatch"
 
 
 async def test_unknown_col_returns_unknown_field(client: AsyncTestClient) -> None:
-    type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, _field_id, schema_version = await seed_asset_type_with_field(client)
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={"col:bogus": "x"}),
+        event_envelope(type_id=type_id, values={"col:bogus": "x"}),
     )
     assert outcome["outcome"] == "rejected:unknown_field"
 
 
 async def test_reserved_col_is_invalid_payload_shape(client: AsyncTestClient) -> None:
-    type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, _field_id, schema_version = await seed_asset_type_with_field(client)
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={"col:deleted": True}),
+        event_envelope(type_id=type_id, values={"col:deleted": True}),
     )
     assert outcome["outcome"] == "rejected:invalid_payload_shape"
 
@@ -258,11 +212,11 @@ async def test_reserved_col_is_invalid_payload_shape(client: AsyncTestClient) ->
 async def test_non_uuid_non_col_key_is_invalid_payload_shape(
     client: AsyncTestClient,
 ) -> None:
-    type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, _field_id, schema_version = await seed_asset_type_with_field(client)
     outcome = await _post_one(
         client,
         schema_version,
-        _event(type_id=type_id, values={"not-a-uuid": "x"}),
+        event_envelope(type_id=type_id, values={"not-a-uuid": "x"}),
     )
     assert outcome["outcome"] == "rejected:invalid_payload_shape"
 
@@ -270,12 +224,12 @@ async def test_non_uuid_non_col_key_is_invalid_payload_shape(
 async def test_deactivated_or_activated_event_has_no_value_validation(
     client: AsyncTestClient,
 ) -> None:
-    type_id, _field_id, schema_version = await _seed_asset_type_with_field(client)
+    type_id, _field_id, schema_version = await seed_asset_type_with_field(client)
     outcome = await _post_one(
         client,
         schema_version,
         {
-            "hlc": _VALID_HLC,
+            "hlc": DEFAULT_HLC,
             "family": "asset",
             "type_id": type_id,
             "instance_id": str(uuid4()),
@@ -304,7 +258,7 @@ async def test_mr_created_without_parent_is_invalid_payload_shape(
         client,
         schema_version,
         {
-            "hlc": _VALID_HLC,
+            "hlc": DEFAULT_HLC,
             "family": "maintenance_record",
             "type_id": type_id,
             "instance_id": str(uuid4()),


### PR DESCRIPTION
## Summary

Stacked on #130. Four endpoint test files (`drift`, `idempotency`, `schema_version`, `validation`) each defined their own `_event` builder for `POST /events` payloads, all producing the same wire shape. Hoist a single `event_envelope(...)` into `tests/events/_http_helpers.py` with kwargs-only signature plus a `DEFAULT_HLC` constant; also move the `seed_asset_type_with_field` helper there (previously inlined in `test_endpoint_validation.py`).

**Net change:** +133 / −134 LOC (effectively neutral, but each consumer is several lines smaller).

### What stays inline

- `tests/events/test_endpoint_e2e.py` keeps its own `_created_event` / `_mr_created_event` builders — they support the family + parent variations the full-pipeline tests need (UUIDs not strings, `parent` field, MR family).
- `tests/events/test_validators.py` keeps its in-memory `EventEnvelope` factory — different return type (Python object, not wire dict), different purpose.
- Inline literal dicts in `test_endpoint_validation.py` that don't match the helper's shape (`updated`/`deactivated` bodies, no-parent maintenance_record case) stay inline.

### API shape

`event_envelope` takes kwargs only and defaults to a minimal-valid asset `created` event. Sticking to 5 args (`max-args = 5` per ruff/PLR0913) means it covers what every caller in this scope actually overrides (`type_id`, `hlc`, `instance_id`, `values`). Family/event-type overrides aren't added speculatively — when the next test wants them, the helper grows then.

## Test plan

- [x] `uv run pytest tests/events` → 159 passed
- [x] `uv run pytest` → 529 passed
- [x] `uv run ruff check` → ratchet baseline matches (no new PLR0913 / E501)
- [x] `just format` clean
- [x] `ty check` clean