### PR TITLE
docs(adr): flip ADR-009 to Accepted (M2.5 Pass 2, closes #35)

### DIFF
--- a/docs/adr/009-mandatory-schema-upgrade.md
+++ b/docs/adr/009-mandatory-schema-upgrade.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (2026-05-28)
 
 ## Context
 


### PR DESCRIPTION
## Summary

M2.5 Pass 2 ADR acceptance — closes #35.

- **ADR-009** (mandatory schema upgrade): flipped Proposed -> Accepted (2026-05-28). The schema-version gate (M1.3) plus catch-up flow (M2.2) close the loop.
- **ADR-015** (initial sync): already Accepted in c424284 (M2.3) — no change needed this pass.
- **ADR-008** (server-authoritative schema): prose reviewed against the implemented `GET /schema` handler (`src/py/novamoc/domain/schema/controllers/_schema.py`). No contradiction found. The ETag/304 short-circuit uses `schema_version` = `MAX(schema_change_log.seq)` (matches ADR-008's *Versioning* clause); `ORDER BY id` on the projection reads guarantees byte-identical bodies for the same version; `current_version` is read under the same request-scoped WAL snapshot as the projection. ADR-008 specifies the data invariants the implementation enforces and intentionally doesn't pin HTTP-level cache semantics, so the ETag layer sits cleanly above the ADR's contract. No follow-up issue filed.
- **ADR-013** (HTTP + WS transports): not flipped — M3 owns the WS half.

ADR body untouched per the project's ADR immutability rule; only the Status section moved.

## Test plan

- [x] `just typecheck-py` — passes
- [x] `just test-py` — 543 passed
- [x] `just ratchet` — baseline matches
- [x] `git diff` — single-line Status change in `docs/adr/009-mandatory-schema-upgrade.md`

Note: full `just check` fails on this branch for two pre-existing reasons unrelated to this PR — (1) `typecheck-js` exits 127 because `svelte-kit` isn't installed in the worktree, and (2) `lint-py` prints residual non-fixable violations whose counts are absorbed by the ratchet (baseline matches, so CI is green). Both reproduce on `main` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)