### PR TITLE
fix(auth): close login timing oracle on unknown/disabled user paths

### DIFF
--- a/src/py/novamoc/domain/accounts/_handlers.py
+++ b/src/py/novamoc/domain/accounts/_handlers.py
@@ -8,7 +8,10 @@ against the in-memory engine fixtures.
 Anti-enumeration: every failure path in :func:`login` (unknown user,
 wrong password, disabled user, zero memberships) raises the same
 :class:`LoginFailedError` so the wire byte-pattern is identical across
-shapes (ADR-020).
+shapes (ADR-020). Every path also incurs exactly one argon2id verify
+call so the four branches are timing-equivalent — the unknown-user
+and disabled-user branches verify against a dummy hash with the
+hasher's own cost parameters (issue #134).
 
 The session middleware that gives ``request.set_session`` /
 ``request.clear_session`` their teeth lands in M5.11; the handlers here
@@ -82,14 +85,29 @@ async def login(
     upgrade: the user's ``password_hash`` is rewritten with the current
     cost parameters so cost rotations propagate as users log in.
 
+    Anti-enumeration extends past the wire body to the timing layer
+    (issue #134): the unknown-user and disabled-user branches verify
+    against a dummy hash whose cost parameters match the live hasher,
+    so an attacker cannot distinguish "user does not exist" /
+    "user is disabled" from "wrong password" by latency. The verify
+    is the constant-time component; no artificial sleep.
+
     Raises:
         LoginFailedError: any credential-rejection path.
     """
     user = await users.get_by_username(data.username)
+    plaintext = data.password.get_secret_value()
+
+    # Unknown user / disabled user: still spend an argon2id verify
+    # against a dummy hash so the latency of these branches matches a
+    # real verify (ADR-020 anti-enumeration, #134). The dummy hash
+    # carries this hasher's cost parameters so the work is parity by
+    # construction; the verify always returns False, which the caller
+    # discards.
     if user is None or user.disabled_at is not None:
+        password_hasher.verify(password_hasher.dummy_hash(), plaintext)
         raise LoginFailedError
 
-    plaintext = data.password.get_secret_value()
     if not password_hasher.verify(user.password_hash, plaintext):
         raise LoginFailedError
 

--- a/src/py/novamoc/domain/accounts/_password.py
+++ b/src/py/novamoc/domain/accounts/_password.py
@@ -14,6 +14,7 @@ no I/O) and a frozen dataclass cannot hold a mutable private attribute without
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 
 import argon2
@@ -70,6 +71,28 @@ class PasswordHasher:
         """
         return self._inner().hash(password)
 
+    def dummy_hash(self) -> str:
+        """Return a fixed-content argon2id hash with this instance's parameters.
+
+        The hash is deterministic per ``(time_cost, memory_cost_kib,
+        parallelism)`` triple and cached at module level so each
+        parameter set pays the construction cost only once. The login
+        handler (M5.10) calls this on the unknown-user / disabled-user
+        branches to feed :meth:`verify` real work whose runtime
+        matches a real user's verify — closing the anti-enumeration
+        timing oracle (issue #134, ADR-020).
+
+        The plaintext (``""``), salt (whatever argon2-cffi generates),
+        and embedded encoding don't matter to callers; ``verify`` will
+        always reject and timing parity is the sole correctness
+        property.
+
+        Returns:
+            An encoded ``$argon2id$...`` string with this instance's
+            cost parameters baked in.
+        """
+        return _build_dummy_hash(self.time_cost, self.memory_cost_kib, self.parallelism)
+
     def verify(self, encoded: str, password: str) -> bool:
         """Verify *password* against an argon2id-encoded hash.
 
@@ -108,3 +131,19 @@ class PasswordHasher:
             return self._inner().check_needs_rehash(encoded)
         except argon2.exceptions.InvalidHashError:
             return True
+
+
+@functools.cache
+def _build_dummy_hash(time_cost: int, memory_cost_kib: int, parallelism: int) -> str:
+    """Build a one-time argon2id hash with the given parameters.
+
+    Cached on the parameter triple so each unique cost configuration
+    pays the hash cost exactly once per process. The plaintext is
+    fixed (empty string) — only the cost-parameter parity matters to
+    callers.
+    """
+    return argon2.PasswordHasher(
+        time_cost=time_cost,
+        memory_cost=memory_cost_kib,
+        parallelism=parallelism,
+    ).hash("")

--- a/tests/accounts/test_handlers.py
+++ b/tests/accounts/test_handlers.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import pytest
 from msgspec_ext import SecretStr
@@ -59,6 +59,38 @@ pytestmark = pytest.mark.no_tenant
 # parameters as ``tests/accounts/test_password.py`` so login round-trips
 # stay sub-second.
 _FAST = PasswordHasher(time_cost=1, memory_cost_kib=8192, parallelism=1)
+
+
+class _CountingPasswordHasher(PasswordHasher):
+    """:class:`PasswordHasher` that records each :meth:`verify` call.
+
+    Used by the anti-enumeration tests in this module to assert every
+    rejection branch of :func:`login` incurs exactly one argon2id
+    verify — the timing-channel half of ADR-020's anti-enumeration
+    promise. The hasher still runs the real argon2 verify (no
+    substitution of the work the side-channel exists to mask); the
+    subclass only adds the counter.
+
+    ``slots=True`` on the parent forbids new instance attributes, so
+    the counter lives on a class-level ``ClassVar`` list. Tests share
+    one instance per test function (no parallel test workers) so
+    cross-test bleed is impossible.
+    """
+
+    verify_calls: ClassVar[list[tuple[str, str]]] = []
+
+    def verify(self, encoded: str, password: str) -> bool:
+        _CountingPasswordHasher.verify_calls.append((encoded, password))
+        return super().verify(encoded, password)
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.verify_calls.clear()
+
+
+_COUNTING_FAST = _CountingPasswordHasher(
+    time_cost=1, memory_cost_kib=8192, parallelism=1
+)
 
 
 @dataclass
@@ -303,6 +335,115 @@ async def test_login_rehashes_password_when_parameters_rotate(
     reloaded = await users.get(item_id=user.id)
     assert reloaded.password_hash != original_hash
     assert stronger.verify(reloaded.password_hash, "hunter2") is True
+
+
+# ----- anti-enumeration: every 401 path runs verify exactly once ------------
+
+
+async def test_login_unknown_user_still_runs_one_verify(
+    session: AsyncSession,
+) -> None:
+    """Unknown-user 401 must spend an argon2id verify (#134, ADR-020).
+
+    The anti-enumeration promise is byte-equal at the wire AND
+    timing-equal at the handler. An attacker probing for valid
+    usernames cannot distinguish "user does not exist" from
+    "wrong password" by latency if every path budgets one verify.
+    """
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+    _CountingPasswordHasher.reset()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="nobody", password=SecretStr("hunter2")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_COUNTING_FAST,
+        )
+    assert len(_CountingPasswordHasher.verify_calls) == 1
+
+
+async def test_login_disabled_user_still_runs_one_verify(
+    session: AsyncSession,
+) -> None:
+    """Disabled-user 401 must spend an argon2id verify (#134, ADR-020)."""
+    await _make_user(
+        session,
+        "alice",
+        "hunter2",
+        hasher=_COUNTING_FAST,
+        disabled_at=datetime.now(tz=UTC),
+    )
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+    _CountingPasswordHasher.reset()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="alice", password=SecretStr("hunter2")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_COUNTING_FAST,
+        )
+    assert len(_CountingPasswordHasher.verify_calls) == 1
+
+
+async def test_login_wrong_password_runs_one_verify(
+    session: AsyncSession,
+) -> None:
+    """Wrong-password 401 already runs verify — regression guard."""
+    user = await _make_user(session, "alice", "correct-horse", hasher=_COUNTING_FAST)
+    tenant = await _make_tenant(session, "Acme")
+    await _grant_membership(session, user, tenant)
+
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+    _CountingPasswordHasher.reset()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="alice", password=SecretStr("wrong-pw")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_COUNTING_FAST,
+        )
+    assert len(_CountingPasswordHasher.verify_calls) == 1
+
+
+async def test_login_zero_membership_runs_one_verify(
+    session: AsyncSession,
+) -> None:
+    """Zero-membership 401 already runs verify — regression guard.
+
+    The check sits after the verify call in the current handler, so
+    this asserts the existing behaviour (the issue notes that this
+    path should be left untouched). Pinning it as a separate test
+    prevents a future refactor from accidentally hoisting the
+    membership check above the verify.
+    """
+    await _make_user(session, "alice", "hunter2", hasher=_COUNTING_FAST)
+
+    users = UserService(session=session)
+    memberships = UserTenantMembershipService(session=session)
+    request = _FakeRequest()
+    _CountingPasswordHasher.reset()
+
+    with pytest.raises(LoginFailedError):
+        await login(
+            request=request,
+            data=LoginRequest(username="alice", password=SecretStr("hunter2")),
+            users=users,
+            memberships=memberships,
+            password_hasher=_COUNTING_FAST,
+        )
+    assert len(_CountingPasswordHasher.verify_calls) == 1
 
 
 # ----- logout ---------------------------------------------------------------

--- a/tests/accounts/test_login_e2e.py
+++ b/tests/accounts/test_login_e2e.py
@@ -15,15 +15,29 @@ credential leak, not a styling issue.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
+from advanced_alchemy.alembic.commands import AlembicCommands
+from advanced_alchemy.base import metadata_registry
 from advanced_alchemy.extensions.litestar import (
     SQLAlchemyAsyncConfig,
     SQLAlchemyPlugin,
 )
+from litestar.testing import AsyncTestClient
 
+from novamoc.asgi import create_app
+from novamoc.config import (
+    AppSettings,
+    AuthSettings,
+    DatabaseSettings,
+    ServerSettings,
+    Settings,
+)
+from novamoc.db.config import build_alchemy_config
 from novamoc.domain.accounts._services import (
     UserService,
     UserTenantMembershipService,
@@ -32,8 +46,9 @@ from tests._constants import DEV_PASSWORD, DEV_USERNAME
 from tests.conftest import seed_dev_admin
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from litestar import Litestar
-    from litestar.testing import AsyncTestClient
 
 
 # The auth registry tables (``users``, ``tenants``, ``user_tenant_memberships``)
@@ -249,3 +264,136 @@ async def test_extra_field_returns_400_invalid_payload_shape(
     body = resp.json()
     assert body["status"] == 400
     assert body["type"] == "http://test/problems/invalid_payload_shape.html"
+
+
+@pytest.fixture
+def timing_settings() -> Settings:
+    """Heavier argon2 so the verify-vs-no-verify gap is unambiguous.
+
+    The conftest settings (``time_cost=1, memory_cost_kib=8192``)
+    keep the e2e suite snappy but bring one verify to only ~10 ms;
+    HTTP round-trip jitter on noisy CI runners can mask a missing
+    verify at that cost. The timing test below mints its own app
+    over these heavier parameters (``time_cost=3,
+    memory_cost_kib=16384``, ~50-80 ms per verify) so a regression
+    that skips verify on any path is unmistakable.
+    """
+    return Settings(
+        db=DatabaseSettings(
+            url="sqlite+aiosqlite:///:memory:",
+            static_pool=True,
+            before_send_handler="autocommit",
+        ),
+        server=ServerSettings(granian=False),
+        app=AppSettings(docs_base_url="http://test"),
+        auth=AuthSettings(
+            argon2_time_cost=3,
+            argon2_memory_cost_kib=16384,
+            argon2_parallelism=1,
+            session_cookie_secure=False,
+        ),
+    )
+
+
+@pytest.fixture
+async def timing_app(timing_settings: Settings) -> AsyncIterator[Litestar]:
+    """A live ``Litestar`` over ``timing_settings``.
+
+    Re-implements the conftest's ``app`` fixture against the heavier
+    settings — the conftest fixture takes ``settings`` from the
+    ambient resolution which is the cheap-argon2 default, and there
+    is no parametrize hook into it.
+    """
+    alchemy_config = build_alchemy_config(timing_settings)
+    engine = alchemy_config.get_engine()
+    async with engine.begin() as conn:
+        for key in metadata_registry:
+            await conn.run_sync(metadata_registry[key].create_all)
+    await asyncio.to_thread(AlembicCommands(alchemy_config).stamp, "head")
+    try:
+        yield create_app(settings=timing_settings, alchemy_config=alchemy_config)
+    finally:
+        await engine.dispose()
+
+
+async def test_all_401_paths_have_comparable_latency(
+    timing_app: Litestar,
+) -> None:
+    """Anti-enumeration: timing-equal across the four 401 paths (#134).
+
+    ADR-020 promises the byte-identical 401 body is anti-enumeration;
+    that promise also has to hold at the timing layer or an attacker
+    reads the oracle through latency instead of through the wire
+    body. Every path must incur exactly one argon2id verify.
+
+    Tolerance: max/min ratio <= 1.7x and absolute spread <= 60 ms.
+    With the bug present at default conftest cost the spread was
+    ~17 ms (ratio ~2x); the ``timing_app`` fixture raises argon2
+    cost so one verify is ~50-80 ms — a regression that skips
+    verify on any path drops that path's latency by ~50 ms, sitting
+    well above HTTP round-trip jitter. Three trials per path, take
+    the minimum, smooths over GC pauses and event-loop hiccups.
+    """
+    async with AsyncTestClient(timing_app) as client:
+        await seed_dev_admin(timing_app)
+
+        async def _time_login(username: str, password: str) -> float:
+            samples = []
+            for _ in range(3):
+                t0 = time.perf_counter()
+                resp = await client.post(
+                    "/auth/login",
+                    json={"username": username, "password": password},
+                )
+                samples.append(time.perf_counter() - t0)
+                assert resp.status_code == 401
+            return min(samples)
+
+        # Path 1: wrong password (user exists, enabled, has membership).
+        wrong_pw = await _time_login(DEV_USERNAME, "not-the-password")
+
+        # Path 2: unknown username (no row at all).
+        unknown = await _time_login("ghost", DEV_PASSWORD)
+
+        # Path 3: disabled user (row present, ``disabled_at`` set).
+        await _disable_admin(timing_app)
+        disabled = await _time_login(DEV_USERNAME, DEV_PASSWORD)
+
+        # Path 4: re-enable the user, drop the membership, measure.
+        async with await _session_factory(timing_app) as db_session:
+            users = UserService(session=db_session)
+            memberships = UserTenantMembershipService(session=db_session)
+            user = await users.get_by_username(DEV_USERNAME)
+            assert user is not None
+            await users.update(
+                data={"disabled_at": None},
+                item_id=user.id,
+                auto_commit=False,
+            )
+            membership = await memberships.get_for_user(user.id)
+            assert membership is not None
+            await memberships.delete(
+                item_id=(membership.user_id, membership.tenant_id),
+                auto_commit=False,
+            )
+            await db_session.commit()
+        zero_membership = await _time_login(DEV_USERNAME, DEV_PASSWORD)
+
+    timings = {
+        "wrong_pw": wrong_pw,
+        "unknown": unknown,
+        "disabled": disabled,
+        "zero_membership": zero_membership,
+    }
+    fastest = min(timings.values())
+    slowest = max(timings.values())
+    spread = slowest - fastest
+    ratio = slowest / fastest if fastest > 0 else float("inf")
+
+    summary = ", ".join(f"{k}={v * 1000:.1f}ms" for k, v in timings.items())
+    diagnostic = (
+        f"latency spread above anti-enumeration budget: {summary} "
+        f"(ratio={ratio:.2f}x, spread={spread * 1000:.1f}ms)"
+    )
+    assert ratio <= 1.7, diagnostic
+    assert spread <= 0.060, diagnostic


### PR DESCRIPTION
## Summary

Closes #134.

ADR-020 promises anti-enumeration on `POST /auth/login` — wrong password, unknown user, disabled user, and zero-membership all share one byte-identical 401 `login_failed` body. The wire-body invariant held, but the handler returned before `password_hasher.verify(...)` ran when the user row was absent or disabled — leaving a timing side-channel that re-opened the user-enumeration oracle the ADR set out to close.

- Every 401 reject path now runs exactly one argon2id verify call.
- The unknown-user / disabled-user branches verify against a dummy hash via the new `PasswordHasher.dummy_hash()` helper. The dummy is cached at module level keyed on the live hasher's `(time_cost, memory_cost_kib, parallelism)` triple, so cost parity with the real path is exact — no hard-coded constants that could drift if hasher params change.
- No artificial sleeps; the argon2id verify itself is the constant-time component.

## Measurements

Verify-call counts on the four 401 paths:

| Path             | Before | After |
| ---------------- | ------ | ----- |
| Unknown user     | 0      | 1     |
| Disabled user    | 0      | 1     |
| Wrong password   | 1      | 1     |
| Zero membership  | 1      | 1     |

Wall-clock latency (3 samples per path, argon2 `time_cost=3, memory_cost_kib=16384`):

```
before: wrong_pw=84.6ms, unknown=18.6ms, disabled=16.3ms, zero_membership=109.1ms — ratio=6.71x, spread=92.8ms
after:  wrong_pw=88.9ms, unknown=82.0ms, disabled=87.7ms, zero_membership=79.3ms  — ratio=1.12x, spread=9.5ms
```

Timing-budget assertion: `ratio <= 1.7x and spread <= 60ms`. Ran 13/13 consecutive without a flake.

## Test plan

- [x] `just check` clean (lint + format + typecheck + test) — 548 passed
- [x] `just ratchet` — no rule-count regressions (PT018 split into two asserts to keep the baseline at 0)
- [x] M5.12 byte-identical wire-body test (`test_wrong_password_and_unknown_user_indistinguishable`) still passes
- [x] Timing test reproduces both the pre-fix oracle and the post-fix parity
- [x] No `unittest.mock` introduced — used a `_CountingPasswordHasher` subclass per the project's test-style convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)