### PR TITLE
fix(schema): wipe data projection on clear_*_field (closes #7)

### DIFF
--- a/src/py/novamoc/domain/schema/_handlers/asset_type_field.py
+++ b/src/py/novamoc/domain/schema/_handlers/asset_type_field.py
@@ -6,10 +6,12 @@ validation) and inserts a new row; ``activate`` takes ``{}`` and only
 flips ``active = true`` on an existing row. ``create`` validates that
 the parent asset_type exists; a deactivated parent is allowed.
 
-TODO(#7): The ``clear`` handler appends a change-log row but does
-**not** wipe field values from the data-projection store. That wipe is
-gated on the data-projection spec and will be implemented once the EAV
-projection tables land.
+``clear`` (ADR-008) wipes the field's rows from the data projection
+in the same transaction as the schema-change-log append: every
+``asset_field_values`` row with ``field_id = <entity_id>`` is deleted,
+and every ``assets.properties`` JSON that contains the key is rewritten
+to set the value to JSON ``null`` (ADR-019). The actual SQL lives in
+:mod:`novamoc.domain.schema._projection_wipe`.
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ from novamoc.domain._errors import (
 )
 from novamoc.domain.schema._commands import SchemaCommand
 from novamoc.domain.schema._outcomes import Outcome, SchemaCommitOutcome
+from novamoc.domain.schema._projection_wipe import FieldFamily, wipe_field_projection
 
 if TYPE_CHECKING:
     from novamoc.domain.accounts import RequestAuth
@@ -152,11 +155,15 @@ async def deactivate(
 async def clear(
     services: ServiceBundle, auth: RequestAuth, req: _payloads.ClearAssetTypeField
 ) -> SchemaCommitOutcome:
-    # TODO(#7): Wipe field values from the data-projection store once EAV projection
-    # tables land. For now only append the change-log row.
     obj = await services.asset_type_field.get_one_or_none(id=req.entity_id)
     if obj is None:
         raise EntityNotFoundError(code=ErrorCode.ENTITY_NOT_FOUND)
+    await wipe_field_projection(
+        services.asset_type_field.repository.session,
+        family=FieldFamily.ASSET,
+        tenant_id=auth.tenant_id,
+        field_id=req.entity_id,
+    )
     row = await services.change_log.append(
         command=SchemaCommand.CLEAR_ASSET_TYPE_FIELD,
         entity_id=req.entity_id,

--- a/src/py/novamoc/domain/schema/_handlers/maintenance_record_type_field.py
+++ b/src/py/novamoc/domain/schema/_handlers/maintenance_record_type_field.py
@@ -2,11 +2,10 @@
 
 Mirror of :mod:`novamoc.domain.schema._handlers.asset_type_field`
 against the maintenance-record-type-field service. Per ADR-008
-``create`` and ``activate`` are separate verbs.
-
-TODO(#7): The ``clear`` handler appends a change-log row but does not
-yet wipe field values from the data-projection store; gated on the
-data-projection spec.
+``create`` and ``activate`` are separate verbs; ``clear`` wipes the
+data projection (``maintenance_record_field_values`` rows + the
+field's key in each ``maintenance_records.properties`` JSON) in the
+same transaction as the schema-change-log append (ADR-008 / ADR-019).
 """
 
 from __future__ import annotations
@@ -24,6 +23,7 @@ from novamoc.domain._errors import (
 )
 from novamoc.domain.schema._commands import SchemaCommand
 from novamoc.domain.schema._outcomes import Outcome, SchemaCommitOutcome
+from novamoc.domain.schema._projection_wipe import FieldFamily, wipe_field_projection
 
 if TYPE_CHECKING:
     from novamoc.domain.accounts import RequestAuth
@@ -151,11 +151,15 @@ async def clear(
     auth: RequestAuth,
     req: _payloads.ClearMaintenanceRecordTypeField,
 ) -> SchemaCommitOutcome:
-    # TODO(#7): Wipe field values from the data-projection store once EAV
-    # projection tables land.
     obj = await services.maintenance_record_type_field.get_one_or_none(id=req.entity_id)
     if obj is None:
         raise EntityNotFoundError(code=ErrorCode.ENTITY_NOT_FOUND)
+    await wipe_field_projection(
+        services.maintenance_record_type_field.repository.session,
+        family=FieldFamily.MAINTENANCE_RECORD,
+        tenant_id=auth.tenant_id,
+        field_id=req.entity_id,
+    )
     row = await services.change_log.append(
         command=SchemaCommand.CLEAR_MAINTENANCE_RECORD_TYPE_FIELD,
         entity_id=req.entity_id,

--- a/src/py/novamoc/domain/schema/_projection_wipe.py
+++ b/src/py/novamoc/domain/schema/_projection_wipe.py
@@ -1,0 +1,121 @@
+"""Data-projection wipe for ``clear_*_field`` (issue #7, ADR-008 / ADR-019).
+
+A ``clear_*_field`` schema command is the only schema verb that touches the
+**data** projection: per ADR-008 it "wipes ``*_field_values`` rows for that
+``field_id`` and removes the field's key from each affected ``properties``
+JSON", as amended by ADR-019 which keeps the JSON key present with value
+``null`` rather than removing it.
+
+This module owns both halves of that wipe so the schema handler can express
+the data-projection concern in one call. The work is two Core SQL statements
+per family:
+
+1. ``DELETE FROM <family>_field_values WHERE tenant_id = ? AND field_id = ?``
+2. ``UPDATE <family> SET properties = json_set(properties, '$.<field_id>',
+   NULL) WHERE tenant_id = ? AND json_type(properties, '$.<field_id>')
+   IS NOT NULL``
+
+Step 2's ``json_type IS NOT NULL`` predicate guards the ADR-019 invariant
+("fields appear only after their first write" — never-touched fields stay
+absent from ``properties``). It also makes the wipe idempotent: a second
+clear finds JSON ``null`` already there (``json_type`` returns ``'null'``,
+the string), re-applies ``json_set(..., NULL)``, and the value stays JSON
+``null``.
+
+Tenant scoping is structural — the ``tenant_id`` predicates in the WHERE
+clauses are what Layer 3 of ``db._listeners`` checks for; without them the
+DML would be rejected. The auto-commit before-send-handler commits the
+schema-handler's whole transaction, so these writes land atomically with
+the ``schema_change_log`` append.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import delete, func, update
+
+from novamoc.db.models.data import (
+    Asset,
+    AssetFieldValue,
+    MaintenanceRecord,
+    MaintenanceRecordFieldValue,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class FieldFamily(StrEnum):
+    """Which projection-family a ``clear_*_field`` command targets.
+
+    The schema-side field kinds (``asset_type_field`` /
+    ``maintenance_record_type_field``) map 1:1 to a data-projection family;
+    the same field UUID is the projection's ``field_id`` value.
+    """
+
+    ASSET = "asset"
+    MAINTENANCE_RECORD = "maintenance_record"
+
+
+# Per-family (entity table, field-value table) tuple. Same shape as the
+# fold-side ``_ENTITY_TABLE`` map in ``domain/events/_projection.py``.
+_TABLES = {
+    FieldFamily.ASSET: (Asset, AssetFieldValue),
+    FieldFamily.MAINTENANCE_RECORD: (MaintenanceRecord, MaintenanceRecordFieldValue),
+}
+
+
+def _properties_path(field_id: str) -> str:
+    # Field ids are UUID strings (no dots / special chars), so naive
+    # concatenation produces a valid SQLite JSON path.
+    return f"$.{field_id}"
+
+
+async def wipe_field_projection(
+    session: AsyncSession,
+    *,
+    family: FieldFamily,
+    tenant_id: UUID,
+    field_id: UUID,
+) -> None:
+    """Wipe ``field_id``'s rows from the data projection for ``tenant_id``.
+
+    Two Core SQL statements (see module docstring). Caller is responsible
+    for not committing — the schema controller's ``autocommit`` before-send
+    handler commits the whole transaction at response time.
+    """
+    entity_model, field_value_model = _TABLES[family]
+    field_id_str = str(field_id)
+    path = _properties_path(field_id_str)
+
+    # ``model.__table__`` resolves to a concrete Table at runtime; the SQLA
+    # type stub widens it. Same suppression pattern as the events projection.
+    fv_table = field_value_model.__table__
+    entity_table = entity_model.__table__
+
+    await session.execute(
+        delete(fv_table).where(  # ty: ignore[invalid-argument-type]
+            fv_table.c.tenant_id == tenant_id,
+            fv_table.c.field_id == field_id_str,
+        )
+    )
+
+    await session.execute(
+        update(entity_table)  # ty: ignore[invalid-argument-type]
+        .where(
+            entity_table.c.tenant_id == tenant_id,
+            # ADR-019: only touch rows where the field was previously
+            # written. ``json_type`` returns SQL NULL when the path is
+            # absent and a string ('null', 'text', 'integer', ...) when
+            # present. ``IS NOT NULL`` filters to "key exists in JSON".
+            func.json_type(entity_table.c.properties, path).is_not(None),
+        )
+        .values({"properties": func.json_set(entity_table.c.properties, path, None)})
+    )
+
+
+__all__ = ("FieldFamily", "wipe_field_projection")

--- a/tests/schema/test_endpoint_e2e.py
+++ b/tests/schema/test_endpoint_e2e.py
@@ -1,11 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from novamoc.db._tenant_context import use_tenant
+from novamoc.db.models.data import Asset, AssetFieldValue
+from tests._constants import DEV_TENANT_ID
+
+if TYPE_CHECKING:
+    from litestar import Litestar
 
 
 @pytest.fixture
 def fresh_entity_id() -> str:
     return str(uuid4())
+
+
+def _app_engine(app: Litestar) -> AsyncEngine:
+    # Same lookup the events e2e suite uses — advanced_alchemy stores
+    # the engine under a per-app numeric-suffixed key.
+    for key, value in app.state._state.items():
+        if key.startswith("db_engine") and isinstance(value, AsyncEngine):
+            return value
+    msg = "no SQLAlchemy engine on app state — did lifespan run?"
+    raise RuntimeError(msg)
+
+
+async def _query(app: Litestar, stmt: Any) -> Any:
+    engine = _app_engine(app)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_maker() as session:
+        return await session.execute(stmt)
 
 
 async def test_post_schema_creates_asset_type(client, fresh_entity_id: str) -> None:
@@ -144,6 +173,99 @@ async def test_post_schema_without_session_returns_401(unauth_client) -> None:
     assert body["status"] == 401
     assert body["type"] == "http://test/problems/tenant_not_resolved.html"
     assert body["title"] == "Tenant not resolved"
+
+
+async def test_clear_asset_type_field_wipes_projection(client, app: Litestar) -> None:
+    """``clear_asset_type_field`` deletes field-value rows and nulls the
+    matching key in ``properties`` (issue #7, ADR-008, ADR-019)."""
+    type_id = uuid4()
+    field_id = uuid4()
+    resp = await client.post(
+        "/schema",
+        json={
+            "type": "create_asset_type",
+            "entity_id": str(type_id),
+            "payload": {"name": f"Truck-{type_id}"},
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    resp = await client.post(
+        "/schema",
+        json={
+            "type": "create_asset_type_field",
+            "entity_id": str(field_id),
+            "payload": {
+                "parent_id": str(type_id),
+                "name": "vin",
+                "data_type": "text",
+            },
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+    # Seed an asset + a vin value directly into the projection so we have
+    # something to wipe. The data projection is normally produced by the
+    # events fold; for this targeted test we write the rows directly.
+    asset_id = uuid4()
+    engine = _app_engine(app)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    with use_tenant(DEV_TENANT_ID):
+        async with session_maker() as db:
+            db.add(
+                Asset(
+                    id=asset_id,
+                    tenant_id=DEV_TENANT_ID,
+                    type_id=type_id,
+                    name=None,
+                    properties={str(field_id): "ABC123", "keep": "untouched"},
+                    deleted=False,
+                    row_state_hlc="0001700000000000-00000-aaa",
+                )
+            )
+            db.add(
+                AssetFieldValue(
+                    tenant_id=DEV_TENANT_ID,
+                    asset_id=asset_id,
+                    field_id=str(field_id),
+                    value_json="ABC123",
+                    hlc="0001700000000000-00000-aaa",
+                )
+            )
+            await db.commit()
+
+    resp = await client.post(
+        "/schema",
+        json={
+            "type": "clear_asset_type_field",
+            "entity_id": str(field_id),
+            "payload": {},
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    assert resp.json()["outcome"] == "cleared"
+
+    with use_tenant(DEV_TENANT_ID):
+        rows = (
+            (
+                await _query(
+                    app,
+                    select(AssetFieldValue).where(
+                        AssetFieldValue.field_id == str(field_id)
+                    ),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows == []
+
+        asset = (
+            await _query(app, select(Asset).where(Asset.id == asset_id))
+        ).scalar_one()
+        # ADR-019: key stays as JSON null, sibling keys untouched.
+        assert str(field_id) in asset.properties
+        assert asset.properties[str(field_id)] is None
+        assert asset.properties["keep"] == "untouched"
 
 
 async def test_post_schema_problem_includes_instance_and_extras(client) -> None:

--- a/tests/schema/test_handlers_field.py
+++ b/tests/schema/test_handlers_field.py
@@ -21,7 +21,14 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import select
 
+from novamoc.db._tenant_context import use_tenant
 from novamoc.db.models import schema as schema_models
+from novamoc.db.models.data import (
+    Asset,
+    AssetFieldValue,
+    MaintenanceRecord,
+    MaintenanceRecordFieldValue,
+)
 from novamoc.db.models.schema import FieldDataType
 from novamoc.domain._errors import (
     ConflictError,
@@ -34,7 +41,7 @@ from novamoc.domain.schema import _payloads
 from novamoc.domain.schema._commands import SchemaCommand
 from novamoc.domain.schema._dispatch import dispatch
 from novamoc.domain.schema._outcomes import Outcome
-from tests._constants import DEV_TENANT_ID
+from tests._constants import DEV_TENANT_ID, DEV_TENANT_ID_A, DEV_TENANT_ID_B
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -63,6 +70,9 @@ class FieldSpec:
     update_payload_cls: type
     schema_command_create: SchemaCommand
     schema_command_clear: SchemaCommand
+    entity_model: type[Asset] | type[MaintenanceRecord]
+    field_value_model: type[AssetFieldValue] | type[MaintenanceRecordFieldValue]
+    entity_fk_attr: str
 
 
 ASSET_FIELD = FieldSpec(
@@ -82,6 +92,9 @@ ASSET_FIELD = FieldSpec(
     update_payload_cls=_payloads._AssetTypeFieldUpdatePayload,
     schema_command_create=SchemaCommand.CREATE_ASSET_TYPE_FIELD,
     schema_command_clear=SchemaCommand.CLEAR_ASSET_TYPE_FIELD,
+    entity_model=Asset,
+    field_value_model=AssetFieldValue,
+    entity_fk_attr="asset_id",
 )
 
 MR_FIELD = FieldSpec(
@@ -101,6 +114,9 @@ MR_FIELD = FieldSpec(
     update_payload_cls=_payloads._MaintenanceRecordTypeFieldUpdatePayload,
     schema_command_create=SchemaCommand.CREATE_MAINTENANCE_RECORD_TYPE_FIELD,
     schema_command_clear=SchemaCommand.CLEAR_MAINTENANCE_RECORD_TYPE_FIELD,
+    entity_model=MaintenanceRecord,
+    field_value_model=MaintenanceRecordFieldValue,
+    entity_fk_attr="maintenance_record_id",
 )
 
 _SPECS = pytest.mark.parametrize("spec", [ASSET_FIELD, MR_FIELD], ids=lambda s: s.id)
@@ -135,13 +151,14 @@ async def _make_parent(
     return type_id
 
 
-async def _make_field(
+async def _make_field(  # noqa: PLR0913  # test-helper builder: explicit keyword args > a dict literal
     session: AsyncSession,
     services: ServiceBundle,
     spec: FieldSpec,
     *,
     parent: Any,
     active: bool = True,
+    name: str | None = None,
 ) -> Any:
     fid = uuid4()
     await _field_service(services, spec).create(
@@ -149,7 +166,7 @@ async def _make_field(
             "tenant_id": _T,
             "id": fid,
             "parent_id": parent,
-            "name": spec.sample_name,
+            "name": name if name is not None else spec.sample_name,
             "data_type": spec.sample_data_type.value,
             "validation": None,
             "active": active,
@@ -417,6 +434,345 @@ async def test_clear_field_appends_log_row(
     assert out.outcome is Outcome.CLEARED
     log = (await session.execute(select(schema_models.SchemaChangeLog))).scalars().all()
     assert log[-1].command == spec.schema_command_clear
+
+
+# --- clear wipes the data projection (issue #7, ADR-008, ADR-019) ---
+
+
+async def _make_entity(
+    session: AsyncSession,
+    spec: FieldSpec,
+    *,
+    type_id: Any,
+    tenant_id: Any = DEV_TENANT_ID,
+    properties: dict[str, Any] | None = None,
+) -> Any:
+    """Materialize one row in the entity-table projection.
+
+    ``maintenance_records`` requires both ``type_id`` and ``asset_id``; we
+    seed a minimal :class:`Asset` to satisfy the FK so the test body can
+    stay tenant-spec-agnostic.
+    """
+    eid = uuid4()
+    if spec.entity_model is MaintenanceRecord:
+        # Seed a placeholder asset of *any* type so the MR's asset_id FK
+        # resolves; for the clear-wipe test the asset itself is irrelevant.
+        asset_type_id = uuid4()
+        session.add(
+            schema_models.AssetType(
+                id=asset_type_id,
+                tenant_id=tenant_id,
+                name=f"AT-{asset_type_id}",
+                active=True,
+            )
+        )
+        await session.flush()
+        asset_id = uuid4()
+        session.add(
+            Asset(
+                id=asset_id,
+                tenant_id=tenant_id,
+                type_id=asset_type_id,
+                name=None,
+                properties={},
+                deleted=False,
+                row_state_hlc="0001700000000000-00000-aaa",
+            )
+        )
+        await session.flush()
+        session.add(
+            MaintenanceRecord(
+                id=eid,
+                tenant_id=tenant_id,
+                type_id=type_id,
+                asset_id=asset_id,
+                name=None,
+                properties=properties if properties is not None else {},
+                deleted=False,
+                row_state_hlc="0001700000000001-00000-aaa",
+            )
+        )
+    else:
+        session.add(
+            Asset(
+                id=eid,
+                tenant_id=tenant_id,
+                type_id=type_id,
+                name=None,
+                properties=properties if properties is not None else {},
+                deleted=False,
+                row_state_hlc="0001700000000000-00000-aaa",
+            )
+        )
+    await session.flush()
+    return eid
+
+
+async def _make_field_value(  # noqa: PLR0913  # test-helper builder: explicit keyword args > a dict literal
+    session: AsyncSession,
+    spec: FieldSpec,
+    *,
+    entity_id: Any,
+    field_id: str,
+    value_json: Any,
+    tenant_id: Any = DEV_TENANT_ID,
+    hlc: str = "0001700000000000-00000-aaa",
+) -> None:
+    """Insert one row into the per-(entity, field) projection table."""
+    kwargs = {
+        "tenant_id": tenant_id,
+        spec.entity_fk_attr: entity_id,
+        "field_id": field_id,
+        "value_json": value_json,
+        "hlc": hlc,
+    }
+    session.add(spec.field_value_model(**kwargs))
+    await session.flush()
+
+
+@_SPECS
+async def test_clear_wipes_field_value_rows(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """``clear_*_field`` deletes every ``*_field_values`` row for the field."""
+    parent = await _make_parent(session, services, spec)
+    fid = await _make_field(session, services, spec, parent=parent)
+    other_fid = await _make_field(
+        session,
+        services,
+        spec,
+        parent=parent,
+        name=f"{spec.sample_name}_other",
+    )
+    e1 = await _make_entity(session, spec, type_id=parent)
+    e2 = await _make_entity(session, spec, type_id=parent)
+    await _make_field_value(
+        session, spec, entity_id=e1, field_id=str(fid), value_json="v1"
+    )
+    await _make_field_value(
+        session, spec, entity_id=e2, field_id=str(fid), value_json="v2"
+    )
+    # Other-field row that must survive.
+    await _make_field_value(
+        session, spec, entity_id=e1, field_id=str(other_fid), value_json="keep"
+    )
+
+    out = await dispatch(
+        services,
+        _AUTH,
+        spec.clear_cmd(entity_id=fid, payload=_payloads._Empty()),
+    )
+    await session.flush()
+    assert out.outcome is Outcome.CLEARED
+
+    rows = (
+        (
+            await session.execute(
+                select(spec.field_value_model).where(
+                    spec.field_value_model.field_id == str(fid)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+    # Other field's rows are untouched.
+    surviving = (
+        (
+            await session.execute(
+                select(spec.field_value_model).where(
+                    spec.field_value_model.field_id == str(other_fid)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(surviving) == 1
+
+
+@_SPECS
+async def test_clear_sets_properties_key_to_json_null(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """ADR-019: cleared user-field keys stay in ``properties`` as JSON ``null``."""
+    parent = await _make_parent(session, services, spec)
+    fid = await _make_field(session, services, spec, parent=parent)
+    e1 = await _make_entity(
+        session,
+        spec,
+        type_id=parent,
+        properties={str(fid): "before", "keep": "untouched"},
+    )
+
+    await dispatch(
+        services,
+        _AUTH,
+        spec.clear_cmd(entity_id=fid, payload=_payloads._Empty()),
+    )
+    await session.flush()
+    # Refresh after the UPDATE.
+    session.expire_all()
+
+    row = (
+        await session.execute(
+            select(spec.entity_model).where(spec.entity_model.id == e1)
+        )
+    ).scalar_one()
+    # ADR-019: key present, value JSON null. Distinct from "key missing".
+    assert str(fid) in row.properties
+    assert row.properties[str(fid)] is None
+    # Unrelated keys are untouched.
+    assert row.properties["keep"] == "untouched"
+
+
+@_SPECS
+async def test_clear_is_idempotent_with_no_data(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """``clear`` against a field that has never been written must succeed."""
+    parent = await _make_parent(session, services, spec)
+    fid = await _make_field(session, services, spec, parent=parent)
+    out = await dispatch(
+        services,
+        _AUTH,
+        spec.clear_cmd(entity_id=fid, payload=_payloads._Empty()),
+    )
+    await session.flush()
+    assert out.outcome is Outcome.CLEARED
+
+
+@_SPECS
+async def test_clear_does_not_touch_other_tenant_data(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """Tenant scoping: ``clear`` under tenant A must not delete tenant B's rows.
+
+    Reuses the same UUID for the field and the entity on tenant B to prove
+    the WHERE-by-field-id alone is not enough — the structural ``tenant_id``
+    predicate is what protects the sibling tenant.
+    """
+    # Build identical state under two tenants. The field UUID and entity
+    # UUIDs are reused on both sides on purpose — only the tenant column
+    # differs.
+    with use_tenant(DEV_TENANT_ID_A):
+        parent_a = uuid4()
+        session.add(
+            schema_models.AssetType(
+                id=parent_a, tenant_id=DEV_TENANT_ID_A, name="T-A", active=True
+            )
+            if spec.entity_model is Asset
+            else schema_models.MaintenanceRecordType(
+                id=parent_a, tenant_id=DEV_TENANT_ID_A, name="T-A", active=True
+            )
+        )
+        await session.flush()
+
+        fid = uuid4()
+        field_model_cls = (
+            schema_models.AssetTypeField
+            if spec.entity_model is Asset
+            else schema_models.MaintenanceRecordTypeField
+        )
+        session.add(
+            field_model_cls(
+                id=fid,
+                tenant_id=DEV_TENANT_ID_A,
+                parent_id=parent_a,
+                name="shared-name",
+                data_type=spec.sample_data_type.value,
+                validation=None,
+                active=True,
+            )
+        )
+        eid_a = await _make_entity(
+            session,
+            spec,
+            type_id=parent_a,
+            tenant_id=DEV_TENANT_ID_A,
+            properties={str(fid): "A-val"},
+        )
+        await _make_field_value(
+            session,
+            spec,
+            entity_id=eid_a,
+            field_id=str(fid),
+            value_json="A-val",
+            tenant_id=DEV_TENANT_ID_A,
+        )
+
+    with use_tenant(DEV_TENANT_ID_B):
+        parent_b = uuid4()
+        session.add(
+            schema_models.AssetType(
+                id=parent_b, tenant_id=DEV_TENANT_ID_B, name="T-B", active=True
+            )
+            if spec.entity_model is Asset
+            else schema_models.MaintenanceRecordType(
+                id=parent_b, tenant_id=DEV_TENANT_ID_B, name="T-B", active=True
+            )
+        )
+        await session.flush()
+        session.add(
+            field_model_cls(
+                id=fid,  # SAME field UUID, different tenant.
+                tenant_id=DEV_TENANT_ID_B,
+                parent_id=parent_b,
+                name="shared-name",
+                data_type=spec.sample_data_type.value,
+                validation=None,
+                active=True,
+            )
+        )
+        eid_b = await _make_entity(
+            session,
+            spec,
+            type_id=parent_b,
+            tenant_id=DEV_TENANT_ID_B,
+            properties={str(fid): "B-val"},
+        )
+        await _make_field_value(
+            session,
+            spec,
+            entity_id=eid_b,
+            field_id=str(fid),
+            value_json="B-val",
+            tenant_id=DEV_TENANT_ID_B,
+        )
+
+    # Clear under tenant A only.
+    with use_tenant(DEV_TENANT_ID_A):
+        await dispatch(
+            services,
+            RequestAuth(tenant_id=DEV_TENANT_ID_A),
+            spec.clear_cmd(entity_id=fid, payload=_payloads._Empty()),
+        )
+        await session.flush()
+    session.expire_all()
+
+    # Tenant B's projection survives intact.
+    with use_tenant(DEV_TENANT_ID_B):
+        b_row = (
+            await session.execute(
+                select(spec.entity_model).where(spec.entity_model.id == eid_b)
+            )
+        ).scalar_one()
+        assert b_row.properties == {str(fid): "B-val"}
+
+        b_fv = (
+            (
+                await session.execute(
+                    select(spec.field_value_model).where(
+                        spec.field_value_model.field_id == str(fid)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(b_fv) == 1
 
 
 @_SPECS


### PR DESCRIPTION
## Summary

Implements the data-projection half of `clear_*_field` per ADR-008, as
amended by ADR-019. Until now `clear_asset_type_field` /
`clear_maintenance_record_type_field` only appended a
`schema_change_log` row; the projection went untouched. With the data
projection landed (M2), the wipe can finally happen.

For the family `(family, tenant_id, field_id)` the handler now, in one
transaction with the change-log append:

1. `DELETE FROM <family>_field_values WHERE tenant_id = ? AND field_id = ?`
2. `UPDATE <family> SET properties = json_set(properties, '$.<field_id>', NULL)
    WHERE tenant_id = ? AND json_type(properties, '$.<field_id>') IS NOT NULL`

The `json_type IS NOT NULL` guard preserves the ADR-019 invariant
("fields appear only after their first write") and makes the wipe
idempotent — a second `clear` finds JSON `null` already there,
`json_set` re-applies it, no harm done.

Wipe SQL lives in a new `domain/schema/_projection_wipe.py` (mirror of
the events `domain/events/_projection.py` pattern), so the schema
controller's `ServiceBundle` stays schema-only — the wipe doesn't pull
the data-projection services into the schema layer.

Closes #7.

## Test plan

- [x] `tests/schema/test_handlers_field.py` — 4 new parametrized tests
      across both entity kinds: wipe field-value rows, set
      `properties[field_id]` to JSON `null`, idempotency with no data,
      cross-tenant isolation
- [x] `tests/schema/test_endpoint_e2e.py` — full HTTP round-trip on the
      asset-type-field clear command
- [x] `just lint` / `just format` / `just typecheck-py` / `just test-py`
      green (543 → 552 tests)
- [x] `just ratchet` — baseline matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)