### PR TITLE
feat(schema): case-insensitive uniqueness on schema entity names (closes #75)

### DIFF
--- a/src/py/novamoc/db/migrations/versions/03bcd87f986c_baseline.py
+++ b/src/py/novamoc/db/migrations/versions/03bcd87f986c_baseline.py
@@ -91,7 +91,7 @@ def schema_upgrades() -> None:
         "asset_types",
         sa.Column("tenant_id", sa.GUID(length=16), nullable=False),
         sa.Column("id", sa.GUID(length=16), nullable=False),
-        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(collation="NOCASE"), nullable=False),
         sa.Column("active", sa.Boolean(), server_default="1", nullable=False),
         sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
         sa.Column("created_at", sa.DateTimeUTC(timezone=True), nullable=False),
@@ -145,7 +145,7 @@ def schema_upgrades() -> None:
         "maintenance_record_types",
         sa.Column("tenant_id", sa.GUID(length=16), nullable=False),
         sa.Column("id", sa.GUID(length=16), nullable=False),
-        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(collation="NOCASE"), nullable=False),
         sa.Column("active", sa.Boolean(), server_default="1", nullable=False),
         sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
         sa.Column("created_at", sa.DateTimeUTC(timezone=True), nullable=False),
@@ -225,7 +225,7 @@ def schema_upgrades() -> None:
         sa.Column("tenant_id", sa.GUID(length=16), nullable=False),
         sa.Column("id", sa.GUID(length=16), nullable=False),
         sa.Column("parent_id", sa.GUID(length=16), nullable=False),
-        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(collation="NOCASE"), nullable=False),
         sa.Column(
             "data_type",
             sa.Enum(
@@ -298,7 +298,7 @@ def schema_upgrades() -> None:
         sa.Column("tenant_id", sa.GUID(length=16), nullable=False),
         sa.Column("id", sa.GUID(length=16), nullable=False),
         sa.Column("parent_id", sa.GUID(length=16), nullable=False),
-        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(collation="NOCASE"), nullable=False),
         sa.Column(
             "data_type",
             sa.Enum(

--- a/src/py/novamoc/db/models/schema/_asset_type.py
+++ b/src/py/novamoc/db/models/schema/_asset_type.py
@@ -5,11 +5,14 @@ from uuid import UUID
 
 from advanced_alchemy.base import UUIDAuditBase
 from advanced_alchemy.types import GUID, JsonB
-from sqlalchemy import Enum, ForeignKeyConstraint, UniqueConstraint
+from sqlalchemy import Enum, ForeignKeyConstraint, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .._mixins import TenantScopedMixin
 from ._types import FieldDataType
+
+# Case-insensitive uniqueness; stored case is preserved.
+_NameStr = String(collation="NOCASE")
 
 
 class AssetType(TenantScopedMixin, UUIDAuditBase):
@@ -17,7 +20,7 @@ class AssetType(TenantScopedMixin, UUIDAuditBase):
 
     ``active`` carries the lifecycle flag: a tombstoned row (``active = false``)
     stays in the table to keep its name reserved and to support resurrection.
-    Name uniqueness applies across both states.
+    Name uniqueness applies across both states and is case-insensitive.
     """
 
     __tablename__ = "asset_types"
@@ -25,7 +28,7 @@ class AssetType(TenantScopedMixin, UUIDAuditBase):
         UniqueConstraint("tenant_id", "name", name="uq_asset_types_tenant_name"),
     )
 
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(_NameStr)
     active: Mapped[bool] = mapped_column(default=True, server_default="1")
 
 
@@ -48,7 +51,7 @@ class AssetTypeField(TenantScopedMixin, UUIDAuditBase):
     )
 
     parent_id: Mapped[UUID] = mapped_column(GUID)
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(_NameStr)
     data_type: Mapped[FieldDataType] = mapped_column(
         Enum(FieldDataType, native_enum=False)
     )

--- a/src/py/novamoc/db/models/schema/_maintenance_record_type.py
+++ b/src/py/novamoc/db/models/schema/_maintenance_record_type.py
@@ -5,11 +5,14 @@ from uuid import UUID
 
 from advanced_alchemy.base import UUIDAuditBase
 from advanced_alchemy.types import GUID, JsonB
-from sqlalchemy import Enum, ForeignKeyConstraint, UniqueConstraint
+from sqlalchemy import Enum, ForeignKeyConstraint, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .._mixins import TenantScopedMixin
 from ._types import FieldDataType
+
+# Case-insensitive uniqueness; stored case is preserved.
+_NameStr = String(collation="NOCASE")
 
 
 class MaintenanceRecordType(TenantScopedMixin, UUIDAuditBase):
@@ -22,7 +25,7 @@ class MaintenanceRecordType(TenantScopedMixin, UUIDAuditBase):
         ),
     )
 
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(_NameStr)
     active: Mapped[bool] = mapped_column(default=True, server_default="1")
 
 
@@ -45,7 +48,7 @@ class MaintenanceRecordTypeField(TenantScopedMixin, UUIDAuditBase):
     )
 
     parent_id: Mapped[UUID] = mapped_column(GUID)
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(_NameStr)
     data_type: Mapped[FieldDataType] = mapped_column(
         Enum(FieldDataType, native_enum=False)
     )

--- a/src/py/novamoc/domain/schema/_handlers/asset_type.py
+++ b/src/py/novamoc/domain/schema/_handlers/asset_type.py
@@ -35,6 +35,13 @@ if TYPE_CHECKING:
 async def create(
     services: ServiceBundle, auth: RequestAuth, req: _payloads.CreateAssetType
 ) -> SchemaCommitOutcome:
+    existing = await services.asset_type.get_one_or_none(name=req.payload.name)
+    if existing is not None:
+        raise ConflictError(
+            code=ErrorCode.NAME_RESERVED,
+            name=req.payload.name,
+            existing_name=existing.name,
+        )
     try:
         await services.asset_type.create(
             data={
@@ -94,6 +101,16 @@ async def update(
     payload = msgspec.to_builtins(req.payload)
     if not payload:
         raise PayloadShapeError(code=ErrorCode.PAYLOAD_NO_CHANGES)
+    new_name = payload.get("name")
+    if new_name is not None:
+        # Skip a same-id match: that's just a case-only rename on self.
+        existing = await services.asset_type.get_one_or_none(name=new_name)
+        if existing is not None and existing.id != req.entity_id:
+            raise ConflictError(
+                code=ErrorCode.NAME_RESERVED,
+                name=new_name,
+                existing_name=existing.name,
+            )
     try:
         await services.asset_type.update(
             data=payload,

--- a/src/py/novamoc/domain/schema/_handlers/asset_type_field.py
+++ b/src/py/novamoc/domain/schema/_handlers/asset_type_field.py
@@ -42,6 +42,16 @@ async def create(
     )
     if parent is None:
         raise ConflictError(code=ErrorCode.PARENT_TYPE_NOT_FOUND)
+    existing = await services.asset_type_field.get_one_or_none(
+        parent_id=req.payload.parent_id,
+        name=req.payload.name,
+    )
+    if existing is not None:
+        raise ConflictError(
+            code=ErrorCode.NAME_RESERVED,
+            name=req.payload.name,
+            existing_name=existing.name,
+        )
     try:
         await services.asset_type_field.create(
             data={
@@ -105,6 +115,18 @@ async def update(
     payload = msgspec.to_builtins(req.payload)
     if not payload:
         raise PayloadShapeError(code=ErrorCode.PAYLOAD_NO_CHANGES)
+    new_name = payload.get("name")
+    if new_name is not None:
+        existing = await services.asset_type_field.get_one_or_none(
+            parent_id=obj.parent_id,
+            name=new_name,
+        )
+        if existing is not None and existing.id != req.entity_id:
+            raise ConflictError(
+                code=ErrorCode.NAME_RESERVED,
+                name=new_name,
+                existing_name=existing.name,
+            )
     try:
         await services.asset_type_field.update(
             data=payload,

--- a/src/py/novamoc/domain/schema/_handlers/maintenance_record_type.py
+++ b/src/py/novamoc/domain/schema/_handlers/maintenance_record_type.py
@@ -32,6 +32,15 @@ async def create(
     auth: RequestAuth,
     req: _payloads.CreateMaintenanceRecordType,
 ) -> SchemaCommitOutcome:
+    existing = await services.maintenance_record_type.get_one_or_none(
+        name=req.payload.name,
+    )
+    if existing is not None:
+        raise ConflictError(
+            code=ErrorCode.NAME_RESERVED,
+            name=req.payload.name,
+            existing_name=existing.name,
+        )
     try:
         await services.maintenance_record_type.create(
             data={
@@ -91,6 +100,17 @@ async def update(
     payload = msgspec.to_builtins(req.payload)
     if not payload:
         raise PayloadShapeError(code=ErrorCode.PAYLOAD_NO_CHANGES)
+    new_name = payload.get("name")
+    if new_name is not None:
+        existing = await services.maintenance_record_type.get_one_or_none(
+            name=new_name,
+        )
+        if existing is not None and existing.id != req.entity_id:
+            raise ConflictError(
+                code=ErrorCode.NAME_RESERVED,
+                name=new_name,
+                existing_name=existing.name,
+            )
     try:
         await services.maintenance_record_type.update(
             data=payload,

--- a/src/py/novamoc/domain/schema/_handlers/maintenance_record_type_field.py
+++ b/src/py/novamoc/domain/schema/_handlers/maintenance_record_type_field.py
@@ -41,6 +41,16 @@ async def create(
     )
     if parent is None:
         raise ConflictError(code=ErrorCode.PARENT_TYPE_NOT_FOUND)
+    existing = await services.maintenance_record_type_field.get_one_or_none(
+        parent_id=req.payload.parent_id,
+        name=req.payload.name,
+    )
+    if existing is not None:
+        raise ConflictError(
+            code=ErrorCode.NAME_RESERVED,
+            name=req.payload.name,
+            existing_name=existing.name,
+        )
     try:
         await services.maintenance_record_type_field.create(
             data={
@@ -103,6 +113,18 @@ async def update(
     payload = msgspec.to_builtins(req.payload)
     if not payload:
         raise PayloadShapeError(code=ErrorCode.PAYLOAD_NO_CHANGES)
+    new_name = payload.get("name")
+    if new_name is not None:
+        existing = await services.maintenance_record_type_field.get_one_or_none(
+            parent_id=obj.parent_id,
+            name=new_name,
+        )
+        if existing is not None and existing.id != req.entity_id:
+            raise ConflictError(
+                code=ErrorCode.NAME_RESERVED,
+                name=new_name,
+                existing_name=existing.name,
+            )
     try:
         await services.maintenance_record_type_field.update(
             data=payload,

--- a/tests/schema/test_endpoint_e2e.py
+++ b/tests/schema/test_endpoint_e2e.py
@@ -167,3 +167,38 @@ async def test_post_schema_problem_includes_instance_and_extras(client) -> None:
     assert err["name"] == name
     # Per-occurrence instance.
     assert err["instance"].startswith("urn:uuid:")
+
+
+async def test_post_schema_case_insensitive_collision_includes_existing_name(
+    client,
+) -> None:
+    """A case-only collision returns 409 ``name_reserved`` and the problem
+    body carries ``existing_name`` so the UI can show ``already in use as
+    'Bwah'``."""
+    canonical = f"Bwah-{uuid4().hex[:8]}"
+    create = await client.post(
+        "/schema",
+        json={
+            "type": "create_asset_type",
+            "entity_id": str(uuid4()),
+            "payload": {"name": canonical},
+        },
+    )
+    assert create.status_code in (200, 201), create.text
+
+    offending = canonical.lower()
+    conflict = await client.post(
+        "/schema",
+        json={
+            "type": "create_asset_type",
+            "entity_id": str(uuid4()),
+            "payload": {"name": offending},
+        },
+    )
+    assert conflict.status_code == 409, conflict.text
+    assert conflict.headers["content-type"].startswith("application/problem+json")
+    err = conflict.json()
+    assert err["type"] == "http://test/problems/name_reserved.html"
+    assert err["title"] == "Name reserved"
+    assert err["name"] == offending
+    assert err["existing_name"] == canonical

--- a/tests/schema/test_handlers_field.py
+++ b/tests/schema/test_handlers_field.py
@@ -256,6 +256,158 @@ async def test_create_name_collision(
     assert exc_info.value.code is ErrorCode.NAME_RESERVED
 
 
+@_SPECS
+async def test_create_case_insensitive_collision_reports_existing_name(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """Case-only collision is rejected; ``existing_name`` extra carries the
+    canonical name already on the row."""
+    parent = await _make_parent(session, services, spec)
+    canonical = "VIN-Number"  # mixed case so .lower() != canonical
+    await _field_service(services, spec).create(
+        data={
+            "tenant_id": _T,
+            "id": uuid4(),
+            "parent_id": parent,
+            "name": canonical,
+            "data_type": spec.sample_data_type.value,
+            "validation": None,
+            "active": True,
+        },
+        auto_commit=False,
+    )
+    await session.flush()
+    offending = canonical.lower()
+    with pytest.raises(ConflictError) as exc_info:
+        await dispatch(
+            services,
+            _AUTH,
+            spec.create_cmd(
+                entity_id=uuid4(),
+                payload=spec.create_payload_cls(
+                    parent_id=parent,
+                    name=offending,
+                    data_type=spec.sample_data_type,
+                ),
+            ),
+        )
+    assert exc_info.value.code is ErrorCode.NAME_RESERVED
+    assert exc_info.value.extras["name"] == offending
+    assert exc_info.value.extras["existing_name"] == canonical
+
+
+@_SPECS
+async def test_create_preserves_original_case(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """The visible field name keeps its case; storage is unchanged."""
+    parent = await _make_parent(session, services, spec)
+    fid = uuid4()
+    name = "MixedCaseField"
+    await dispatch(
+        services,
+        _AUTH,
+        spec.create_cmd(
+            entity_id=fid,
+            payload=spec.create_payload_cls(
+                parent_id=parent,
+                name=name,
+                data_type=spec.sample_data_type,
+            ),
+        ),
+    )
+    await session.flush()
+    row = await _field_service(services, spec).get_one_or_none(tenant_id=_T, id=fid)
+    assert row is not None
+    assert row.name == name
+
+
+@_SPECS
+async def test_create_collision_with_tombstoned_field(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """A deactivated field still reserves the name across cases."""
+    parent = await _make_parent(session, services, spec)
+    canonical = "VIN-Number"
+    await _field_service(services, spec).create(
+        data={
+            "tenant_id": _T,
+            "id": uuid4(),
+            "parent_id": parent,
+            "name": canonical,
+            "data_type": spec.sample_data_type.value,
+            "validation": None,
+            "active": False,
+        },
+        auto_commit=False,
+    )
+    await session.flush()
+    with pytest.raises(ConflictError) as exc_info:
+        await dispatch(
+            services,
+            _AUTH,
+            spec.create_cmd(
+                entity_id=uuid4(),
+                payload=spec.create_payload_cls(
+                    parent_id=parent,
+                    name=canonical.lower(),
+                    data_type=spec.sample_data_type,
+                ),
+            ),
+        )
+    assert exc_info.value.code is ErrorCode.NAME_RESERVED
+    assert exc_info.value.extras["existing_name"] == canonical
+
+
+@_SPECS
+async def test_update_rename_case_insensitive_collision(
+    session: AsyncSession, services: ServiceBundle, spec: FieldSpec
+) -> None:
+    """Renaming a field to a case-variant of a sibling's name is rejected.
+
+    Issue #75.
+    """
+    parent = await _make_parent(session, services, spec)
+    canonical = "VIN-Number"
+    await _field_service(services, spec).create(
+        data={
+            "tenant_id": _T,
+            "id": uuid4(),
+            "parent_id": parent,
+            "name": canonical,
+            "data_type": spec.sample_data_type.value,
+            "validation": None,
+            "active": True,
+        },
+        auto_commit=False,
+    )
+    other_id = uuid4()
+    await _field_service(services, spec).create(
+        data={
+            "tenant_id": _T,
+            "id": other_id,
+            "parent_id": parent,
+            "name": "OtherField",
+            "data_type": spec.sample_data_type.value,
+            "validation": None,
+            "active": True,
+        },
+        auto_commit=False,
+    )
+    await session.flush()
+    with pytest.raises(ConflictError) as exc_info:
+        await dispatch(
+            services,
+            _AUTH,
+            spec.update_cmd(
+                entity_id=other_id,
+                payload=spec.update_payload_cls(name=canonical.lower()),
+            ),
+        )
+    assert exc_info.value.code is ErrorCode.NAME_RESERVED
+    assert exc_info.value.extras["existing_name"] == canonical
+
+
 # --- activate ---
 
 

--- a/tests/schema/test_handlers_type.py
+++ b/tests/schema/test_handlers_type.py
@@ -182,6 +182,71 @@ async def test_create_id_collision(
     assert exc_info.value.code is ErrorCode.NAME_RESERVED
 
 
+@_SPECS
+async def test_create_case_insensitive_collision_reports_existing_name(
+    session: AsyncSession, services: ServiceBundle, spec: TypeSpec
+) -> None:
+    """Case differs only — collision fires and ``existing_name`` extra carries the
+    canonical name already in the DB."""
+    await _make(session, services, spec, active=True)
+    offending = spec.sample_name.lower()
+    assert offending != spec.sample_name, (
+        "test spec must use a name with at least one upper-case letter"
+    )
+    with pytest.raises(ConflictError) as exc_info:
+        await dispatch(
+            services,
+            _AUTH,
+            spec.create_cmd(
+                entity_id=uuid4(),
+                payload=spec.create_payload_cls(name=offending),
+            ),
+        )
+    assert exc_info.value.code is ErrorCode.NAME_RESERVED
+    assert exc_info.value.extras["name"] == offending
+    assert exc_info.value.extras["existing_name"] == spec.sample_name
+
+
+@_SPECS
+async def test_create_preserves_original_case(
+    session: AsyncSession, services: ServiceBundle, spec: TypeSpec
+) -> None:
+    """Comparison is case-insensitive; the visible name keeps its case."""
+    eid = uuid4()
+    name = spec.sample_name
+    await dispatch(
+        services,
+        _AUTH,
+        spec.create_cmd(
+            entity_id=eid,
+            payload=spec.create_payload_cls(name=name),
+        ),
+    )
+    await session.flush()
+    row = await _service(services, spec).get_one_or_none(tenant_id=_T, id=eid)
+    assert row is not None
+    assert row.name == name
+
+
+@_SPECS
+async def test_create_collision_with_tombstoned_row(
+    session: AsyncSession, services: ServiceBundle, spec: TypeSpec
+) -> None:
+    """A deactivated row still reserves the name across cases."""
+    await _make(session, services, spec, active=False)
+    with pytest.raises(ConflictError) as exc_info:
+        await dispatch(
+            services,
+            _AUTH,
+            spec.create_cmd(
+                entity_id=uuid4(),
+                payload=spec.create_payload_cls(name=spec.sample_name.lower()),
+            ),
+        )
+    assert exc_info.value.code is ErrorCode.NAME_RESERVED
+    assert exc_info.value.extras["existing_name"] == spec.sample_name
+
+
 # --- activate ---
 
 
@@ -285,6 +350,50 @@ async def test_update_missing_raises_not_found(
                 payload=spec.update_payload_cls(name="X"),
             ),
         )
+
+
+@_SPECS
+async def test_update_rename_case_insensitive_collision(
+    session: AsyncSession, services: ServiceBundle, spec: TypeSpec
+) -> None:
+    """Renaming to a name that differs only in case from another row is rejected,
+    and the ``existing_name`` extra carries the canonical name."""
+    # Two rows with distinct names.
+    existing_id = uuid4()
+    await _service(services, spec).create(
+        data={
+            "tenant_id": _T,
+            "id": existing_id,
+            "name": spec.sample_name,
+            "active": True,
+        },
+        auto_commit=False,
+    )
+    rename_target = spec.rename_to
+    other_id = uuid4()
+    await _service(services, spec).create(
+        data={
+            "tenant_id": _T,
+            "id": other_id,
+            "name": rename_target,
+            "active": True,
+        },
+        auto_commit=False,
+    )
+    await session.flush()
+    # Rename ``rename_target`` row to a case-variant of ``sample_name`` —
+    # collision against ``existing_id``.
+    with pytest.raises(ConflictError) as exc_info:
+        await dispatch(
+            services,
+            _AUTH,
+            spec.update_cmd(
+                entity_id=other_id,
+                payload=spec.update_payload_cls(name=spec.sample_name.lower()),
+            ),
+        )
+    assert exc_info.value.code is ErrorCode.NAME_RESERVED
+    assert exc_info.value.extras["existing_name"] == spec.sample_name
 
 
 @_SPECS


### PR DESCRIPTION
## Summary

Names on the four name-bearing schema tables (`asset_types`,
`asset_type_fields`, `maintenance_record_types`,
`maintenance_record_type_fields`) are now case-insensitive for
uniqueness, while storage preserves the user's chosen case. Today a
tenant could create `Bwah` and `bwah` side by side; with this change
the second create returns 409 `name_reserved` carrying the existing
canonical name in the problem-details extras.

Approach: `COLLATE NOCASE` on the `name` column (option 1 from #75 —
the simplest of the three; SQLite-native; the existing UNIQUE indexes
inherit the collation automatically). ASCII-only is acceptable for v1
per the issue. If/when we move to Postgres this becomes a `citext`
column or a `UNIQUE INDEX ON lower(name)`.

Pre-INSERT collision check in the `create` and `update` handlers now
uses `get_one_or_none(name=...)` — the SQL `=` inherits the column's
`NOCASE` collation, so the lookup matches case-insensitively. The
`update` path skips the check when the rename only changes the
entity's own case.

`ConflictError(NAME_RESERVED)` gains an `existing_name` extension
member (per ADR-016) so the UI can render "already in use as 'Bwah'".

### Migration

Hand-written: autogenerate doesn't compare column collations, and
SQLite has no `ALTER COLUMN` (so `batch_alter_table` rebuilds the
table). New revision `2147d037d4de` rides on top of `03bcd87f986c`.

`db/migrations/env.py` sets `SKIP_TENANT_FILTER=True` on the migration
connection. Without it, `batch_alter_table`'s
`INSERT INTO _alembic_tmp_<table> SELECT * FROM <table>` trips Layer
3 of the tenant-scoping listeners (migrations have no request
context, so the contextvar is unset). The suppression is scoped to
the migration connection only — request-path listeners are
unaffected.

Closes #75.

## Test plan

- [x] `tests/schema/test_handlers_type.py` / `test_handlers_field.py`
      — case-only create collision returns `existing_name`,
      original-case preservation, tombstoned-row reservation, rename
      collision via update — all 4 entity kinds
- [x] `tests/schema/test_endpoint_e2e.py` — e2e check for the
      `existing_name` problem-details field
- [x] `just lint-py` / `just format-py` / `just typecheck-py` / `just test-py` (543 → 560)
- [x] `just db-init` against a fresh DB
- [x] `just db-check` — no model/migration drift
- [x] `just ratchet` — baseline matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)