### PR TITLE
chore: ignore SQLite WAL companion files (-shm/-wal)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,6 @@ CLAUDE.local.md
 # Artifacts
 *.db
 *.sqlite
+*.sqlite-shm
+*.sqlite-wal
 


### PR DESCRIPTION
## Summary

``PRAGMA journal_mode=WAL`` (set on every connect via
``db/_pragmas.py``) produces ``-shm`` and ``-wal`` sidecar files
alongside the main DB file. ``just db-check`` / ``just db-init`` /
ad-hoc local serves leave them in the repo root.

``.gitignore`` already had ``*.db`` and ``*.sqlite``; this adds
``*.sqlite-shm`` and ``*.sqlite-wal`` to round out the pattern.

Surfaced while reviewing PR #153 — the agent's worktree had two
untracked sidecar files after running ``just check``.

## Test plan

- [x] ``git status`` is clean after ``just db-check`` on a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)