### PR TITLE
refactor(cli): atomic bootstrap-admin to fix bootstrap-dev partial-failure leaks (#128)

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,9 +39,10 @@ db-check:
 	uv run alchemy --config novamoc.db.config.alchemy_config check
 
 # Apply migrations, then create the dev tenant + admin user.
-# Idempotent: re-running after the first invocation prints
-# "already exists; nothing to do." and exits cleanly. Production
-# deployments run the equivalent CLI commands in an init container.
+# Single-transaction bootstrap (#128): re-running after any partial
+# failure reuses prior rows instead of accumulating orphan tenants
+# or leaving a tenant-less admin behind. Production deployments run
+# the same ``novamoc bootstrap-admin`` invocation in an init container.
 bootstrap-dev:
 	#!/usr/bin/env bash
 	set -euo pipefail
@@ -63,25 +64,10 @@ bootstrap-dev:
 			;;
 	esac
 	just db-init
-	# ``novamoc user exists`` has a three-way exit contract: 0 = exists,
-	# 1 = absent, 2 = CLI error (bad NOVAMOC_DB_URL, locked file, ...).
-	# Honor all three so a real error doesn't silently become a "user
-	# absent, seed now" decision that creates a partial-state DB.
-	rc=0
-	uv run novamoc user exists admin >/dev/null 2>&1 || rc=$?
-	case "$rc" in
-		0) echo "admin user already exists; nothing to do."; exit 0 ;;
-		1) ;;  # absent → fall through to seeding below
-		*) echo "novamoc user exists failed (exit $rc); aborting." >&2; exit "$rc" ;;
-	esac
-	# Anchor to ``Created tenant <uuid>.`` so future stdout (logging,
-	# deprecation notices) doesn't bleed into the parsed UUID. ``exit``
-	# stops awk after the first match for the same reason.
-	tenant_id=$(uv run novamoc tenant create --display-name "Development" \
-	            | awk '/^Created tenant /{print $3; exit}' | tr -d '.')
-	echo "Created tenant $tenant_id."
-	uv run novamoc user create admin --password admin
-	uv run novamoc user add-to-tenant admin "$tenant_id"
+	uv run novamoc bootstrap-admin \
+		--tenant-display-name "Development" \
+		--username admin \
+		--password admin
 	echo "Bootstrap complete. Login at /login with admin / admin."
 
 # Build python packages

--- a/src/py/novamoc/cli.py
+++ b/src/py/novamoc/cli.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -56,6 +57,23 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass(frozen=True, slots=True)
+class _BootstrapResult:
+    """Per-step decisions from ``bootstrap-admin``'s single transaction.
+
+    ``*_reused`` is ``True`` when an existing row was found and reused,
+    ``False`` when the step inserted a new row. Drives the final
+    operator-facing summary so the recipe's stdout makes the recovery
+    path obvious ("Reused tenant ..., Created membership ...").
+    """
+
+    tenant_id: uuid.UUID
+    username: str
+    tenant_reused: bool
+    user_reused: bool
+    membership_reused: bool
 
 
 def _load_settings() -> Settings:
@@ -159,7 +177,141 @@ def main() -> None:
     * ``tenant`` — tenant registry administration.
     * ``user`` — user registry administration.
     * ``auth`` — session / credential maintenance.
+
+    Plus the standalone :func:`bootstrap_admin` command, which the
+    ``just bootstrap-dev`` recipe drives end-to-end.
     """
+
+
+# ---------------------------------------------------------------------------
+# bootstrap-admin (issue #128)
+# ---------------------------------------------------------------------------
+
+
+@main.command("bootstrap-admin")
+@click.option(
+    "--tenant-display-name",
+    required=True,
+    help="Display name to look up or create on the tenants table.",
+)
+@click.option(
+    "--username",
+    required=True,
+    help="Username for the admin account; case-folded for storage.",
+)
+@click.option(
+    "--password",
+    default=None,
+    help="Password for the admin account. Prompts interactively when omitted.",
+)
+def bootstrap_admin(
+    tenant_display_name: str, username: str, password: str | None
+) -> None:
+    """Atomic tenant + user + membership bootstrap (issue #128).
+
+    Single-transaction replacement for the three-CLI-call dance in
+    ``just bootstrap-dev``. Idempotent in *every* failure mode that
+    matters: a partial run that left a tenant row but no user (#128
+    finding #2) reuses the tenant; a partial run that left a user but
+    no membership (#128 finding #4) creates the membership without
+    duplicating anything.
+
+    Aborts when the target user already belongs to a *different*
+    tenant — the v1 invariant means we cannot silently relocate them,
+    and continuing would leave the operator with an admin pointed at
+    the wrong scope.
+    """
+    _require_nonblank(tenant_display_name, label="--tenant-display-name")
+    _require_nonblank(username, label="--username")
+    plaintext = _require_nonblank(
+        _prompt_password_if_missing(password), label="Password"
+    )
+    settings = _load_settings()
+    hasher = _password_hasher(settings)
+
+    async def work(session: AsyncSession) -> _BootstrapResult:
+        tenants = TenantService(session=session)
+        existing_tenant = await tenants.get_by_display_name(tenant_display_name)
+        if existing_tenant is None:
+            created_tenant = await tenants.create(
+                data={"display_name": tenant_display_name}, auto_commit=False
+            )
+            await session.flush()
+            tenant_id = created_tenant.id
+            tenant_reused = False
+        else:
+            tenant_id = existing_tenant.id
+            tenant_reused = True
+
+        users = UserService(session=session)
+        existing_user = await users.get_by_username(username)
+        if existing_user is None:
+            # Hash inside the create branch so the ~100 ms argon2 cost
+            # is paid only when we actually need a new password hash —
+            # mirrors the ``user create`` command's ordering.
+            hashed = hasher.hash(plaintext)
+            try:
+                created_user = await users.create(
+                    data={"username": username, "password_hash": hashed},
+                    auto_commit=False,
+                )
+            except IntegrityError as exc:
+                msg = f"User '{username}' already exists."
+                raise click.ClickException(msg) from exc
+            await session.flush()
+            user_id = created_user.id
+            folded_username = created_user.username
+            user_reused = False
+        else:
+            user_id = existing_user.id
+            folded_username = existing_user.username
+            user_reused = True
+
+        memberships = UserTenantMembershipService(session=session)
+        existing_membership = await memberships.get_by_user_and_tenant(
+            user_id, tenant_id
+        )
+        if existing_membership is None:
+            try:
+                await memberships.create(
+                    data={"user_id": user_id, "tenant_id": tenant_id},
+                    auto_commit=False,
+                )
+            except UserAlreadyHasTenantError as exc:
+                # Operator safety: refuse to silently relocate an admin
+                # already bound to a different tenant — the v1 invariant
+                # would block it at insert time anyway, and surfacing it
+                # here lets the rollback clean up the would-be tenant /
+                # user created in this same transaction.
+                msg = (
+                    f"User '{folded_username}' already belongs to a different "
+                    "tenant; refusing to bootstrap."
+                )
+                raise click.ClickException(msg) from exc
+            membership_reused = False
+        else:
+            membership_reused = True
+
+        return _BootstrapResult(
+            tenant_id=tenant_id,
+            username=folded_username,
+            tenant_reused=tenant_reused,
+            user_reused=user_reused,
+            membership_reused=membership_reused,
+        )
+
+    result = asyncio.run(_run_in_session(settings, work))
+    click.echo(
+        f"{'Reused' if result.tenant_reused else 'Created'} tenant "
+        f"{result.tenant_id} ({tenant_display_name})."
+    )
+    click.echo(
+        f"{'Reused' if result.user_reused else 'Created'} user {result.username}."
+    )
+    click.echo(
+        f"{'Reused' if result.membership_reused else 'Created'} membership "
+        f"for user {result.username} on tenant {result.tenant_id}."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/py/novamoc/domain/accounts/_services.py
+++ b/src/py/novamoc/domain/accounts/_services.py
@@ -35,6 +35,16 @@ class TenantService(service.SQLAlchemyAsyncRepositoryService[Tenant]):
 
     repository_type = Repo
 
+    async def get_by_display_name(self, display_name: str) -> Tenant | None:
+        """Return the tenant whose ``display_name`` matches verbatim, or ``None``.
+
+        Used by ``novamoc bootstrap-admin`` (issue #128) as the
+        lookup-or-create anchor for the Development tenant. The match is
+        case-sensitive — operator-supplied display names are treated as
+        opaque labels, unlike usernames which fold for anti-impersonation.
+        """
+        return await self.get_one_or_none(display_name=display_name)
+
 
 class UserService(service.SQLAlchemyAsyncRepositoryService[User]):
     """Service for the global user-account registry (ADR-020).
@@ -92,6 +102,18 @@ class UserTenantMembershipService(
         the call site.
         """
         return await self.get_one_or_none(user_id=user_id)
+
+    async def get_by_user_and_tenant(
+        self, user_id: uuid.UUID, tenant_id: uuid.UUID
+    ) -> UserTenantMembership | None:
+        """Return the membership for ``(user_id, tenant_id)`` or ``None``.
+
+        Distinct from :meth:`get_for_user` because ``bootstrap-admin``
+        (issue #128) needs to verify a membership for a *specific*
+        ``(user, tenant)`` pair before deciding to create one — under v2
+        the user may already belong to a different tenant entirely.
+        """
+        return await self.get_one_or_none(user_id=user_id, tenant_id=tenant_id)
 
     async def create(
         self,

--- a/tests/accounts/test_cli.py
+++ b/tests/accounts/test_cli.py
@@ -25,7 +25,7 @@ import pytest
 from advanced_alchemy.alembic.commands import AlembicCommands
 from advanced_alchemy.base import metadata_registry
 from click.testing import CliRunner
-from sqlalchemy import insert, select
+from sqlalchemy import delete, insert, select
 from sqlalchemy.ext.asyncio import create_async_engine
 
 # Importing the models registers their tables on the shared metadata
@@ -35,7 +35,7 @@ from novamoc.cli import main
 from novamoc.config import DatabaseSettings, Settings
 from novamoc.db._pragmas import register_sqlite_pragmas
 from novamoc.db.config import build_alchemy_config
-from novamoc.db.models._auth import Session, User
+from novamoc.db.models._auth import Session, Tenant, User, UserTenantMembership
 from novamoc.domain.accounts._password import PasswordHasher
 
 if TYPE_CHECKING:
@@ -424,3 +424,249 @@ def test_user_exists_returns_two_on_db_error(
     monkeypatch.setenv("NOVAMOC_DB_URL", bad_url)
     result = runner.invoke(main, ["user", "exists", "ghost"])
     assert result.exit_code == 2, (result.exit_code, result.output, result.stderr)
+
+
+# ---------------------------------------------------------------------------
+# bootstrap-admin (issue #128)
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_admin_argv(
+    *,
+    display_name: str = "Development",
+    username: str = "admin",
+    password: str = "admin",  # noqa: S107 — test-only credential
+) -> list[str]:
+    return [
+        "bootstrap-admin",
+        "--tenant-display-name",
+        display_name,
+        "--username",
+        username,
+        "--password",
+        password,
+    ]
+
+
+async def _all_tenants(db_url: str) -> list[tuple[uuid.UUID, str]]:
+    eng = create_async_engine(db_url)
+    try:
+        async with eng.connect() as conn:
+            rows = await conn.execute(
+                select(Tenant.__table__.c.id, Tenant.__table__.c.display_name)
+            )
+            return [(r[0], r[1]) for r in rows.all()]
+    finally:
+        await eng.dispose()
+
+
+async def _all_users(db_url: str) -> list[tuple[uuid.UUID, str]]:
+    eng = create_async_engine(db_url)
+    try:
+        async with eng.connect() as conn:
+            rows = await conn.execute(
+                select(User.__table__.c.id, User.__table__.c.username)
+            )
+            return [(r[0], r[1]) for r in rows.all()]
+    finally:
+        await eng.dispose()
+
+
+async def _all_memberships(db_url: str) -> list[tuple[uuid.UUID, uuid.UUID]]:
+    eng = create_async_engine(db_url)
+    try:
+        async with eng.connect() as conn:
+            rows = await conn.execute(
+                select(
+                    UserTenantMembership.__table__.c.user_id,
+                    UserTenantMembership.__table__.c.tenant_id,
+                )
+            )
+            return [(r[0], r[1]) for r in rows.all()]
+    finally:
+        await eng.dispose()
+
+
+async def _drop_memberships(db_url: str) -> None:
+    """Simulate the partial-failure mode from #128 finding #4."""
+    eng = create_async_engine(db_url)
+    try:
+        async with eng.begin() as conn:
+            await conn.execute(delete(UserTenantMembership.__table__))  # ty: ignore[invalid-argument-type]
+    finally:
+        await eng.dispose()
+
+
+async def _drop_users(db_url: str) -> None:
+    """Simulate the partial-failure mode from #128 finding #2 — user
+    creation aborted between ``tenant create`` and ``user create``."""
+    eng = create_async_engine(db_url)
+    try:
+        async with eng.begin() as conn:
+            await conn.execute(delete(UserTenantMembership.__table__))  # ty: ignore[invalid-argument-type]
+            await conn.execute(delete(User.__table__))  # ty: ignore[invalid-argument-type]
+    finally:
+        await eng.dispose()
+
+
+def test_bootstrap_admin_creates_everything_on_clean_db(
+    runner: CliRunner, db_url: str
+) -> None:
+    """Happy path — single command lays down tenant, user, and membership."""
+    result = runner.invoke(main, _bootstrap_admin_argv())
+    assert result.exit_code == 0, (result.output, result.stderr)
+    assert "Created tenant" in result.stdout
+    assert "Created user admin" in result.stdout
+    assert "Created membership" in result.stdout
+
+    tenants = asyncio.run(_all_tenants(db_url))
+    users = asyncio.run(_all_users(db_url))
+    memberships = asyncio.run(_all_memberships(db_url))
+    assert [t[1] for t in tenants] == ["Development"]
+    assert [u[1] for u in users] == ["admin"]
+    assert len(memberships) == 1
+    assert memberships[0] == (users[0][0], tenants[0][0])
+
+
+def test_bootstrap_admin_is_idempotent(runner: CliRunner, db_url: str) -> None:
+    """Re-running on a fully bootstrapped DB is a no-op (#128 closes the
+    holes in the prior ``user exists admin`` check — the idempotence
+    check now covers the membership row too)."""
+    first = runner.invoke(main, _bootstrap_admin_argv())
+    assert first.exit_code == 0, (first.output, first.stderr)
+
+    second = runner.invoke(main, _bootstrap_admin_argv())
+    assert second.exit_code == 0, (second.output, second.stderr)
+    assert "Reused tenant" in second.stdout
+    assert "Reused user admin" in second.stdout
+    assert "Reused membership" in second.stdout
+
+    tenants = asyncio.run(_all_tenants(db_url))
+    users = asyncio.run(_all_users(db_url))
+    memberships = asyncio.run(_all_memberships(db_url))
+    assert len(tenants) == 1
+    assert len(users) == 1
+    assert len(memberships) == 1
+
+
+def test_bootstrap_admin_recovers_when_membership_missing(
+    runner: CliRunner, db_url: str
+) -> None:
+    """Finding #4 — user + tenant were created but membership never
+    landed. Re-run must restore the membership without creating a new
+    tenant or user."""
+    first = runner.invoke(main, _bootstrap_admin_argv())
+    assert first.exit_code == 0, (first.output, first.stderr)
+    asyncio.run(_drop_memberships(db_url))
+
+    second = runner.invoke(main, _bootstrap_admin_argv())
+    assert second.exit_code == 0, (second.output, second.stderr)
+    assert "Reused tenant" in second.stdout
+    assert "Reused user admin" in second.stdout
+    assert "Created membership" in second.stdout
+
+    tenants = asyncio.run(_all_tenants(db_url))
+    users = asyncio.run(_all_users(db_url))
+    memberships = asyncio.run(_all_memberships(db_url))
+    assert len(tenants) == 1
+    assert len(users) == 1
+    assert len(memberships) == 1
+
+
+def test_bootstrap_admin_recovers_when_user_missing(
+    runner: CliRunner, db_url: str
+) -> None:
+    """Finding #2 — tenant exists from a prior aborted run; ``users``
+    table was rolled back / never written. Re-run must reuse the existing
+    tenant instead of creating another orphan."""
+    first = runner.invoke(main, _bootstrap_admin_argv())
+    assert first.exit_code == 0, (first.output, first.stderr)
+    original_tenant = asyncio.run(_all_tenants(db_url))
+    asyncio.run(_drop_users(db_url))
+
+    second = runner.invoke(main, _bootstrap_admin_argv())
+    assert second.exit_code == 0, (second.output, second.stderr)
+    assert "Reused tenant" in second.stdout
+    assert "Created user admin" in second.stdout
+    assert "Created membership" in second.stdout
+
+    tenants = asyncio.run(_all_tenants(db_url))
+    assert tenants == original_tenant, "tenant id changed across runs"
+
+
+def test_bootstrap_admin_fails_when_user_belongs_to_another_tenant(
+    runner: CliRunner, db_url: str
+) -> None:
+    """Operator safety: if the admin user already belongs to a
+    *different* tenant, the bootstrap must abort with a clear message
+    rather than silently confusing the operator about which tenant the
+    admin lives in."""
+    other = runner.invoke(main, ["tenant", "create", "--display-name", "Other"])
+    assert other.exit_code == 0, other.output
+    runner.invoke(main, ["user", "create", "admin", "--password", "admin"])
+    other_tid = _extract_uuid(other.stdout)
+    runner.invoke(main, ["user", "add-to-tenant", "admin", str(other_tid)])
+
+    result = runner.invoke(main, _bootstrap_admin_argv())
+    assert result.exit_code != 0
+    assert re.search(r"already.*tenant", result.stderr, re.IGNORECASE)
+
+    # Nothing was committed for the Development bootstrap.
+    tenants = asyncio.run(_all_tenants(db_url))
+    assert {t[1] for t in tenants} == {"Other"}
+
+
+def test_bootstrap_admin_folds_username_for_idempotence(
+    runner: CliRunner, db_url: str
+) -> None:
+    """``ADMIN`` and ``admin`` resolve to the same user — re-running
+    with a different case must not duplicate."""
+    first = runner.invoke(
+        main,
+        _bootstrap_admin_argv(username="admin", password="x"),  # noqa: S106 — test-only credential
+    )
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(
+        main,
+        _bootstrap_admin_argv(username="ADMIN", password="x"),  # noqa: S106 — test-only credential
+    )
+    assert second.exit_code == 0, second.output
+    assert "Reused user admin" in second.stdout
+
+    users = asyncio.run(_all_users(db_url))
+    assert [u[1] for u in users] == ["admin"]
+
+
+@pytest.mark.parametrize(
+    "argv_kwargs",
+    [
+        {"display_name": ""},
+        {"username": ""},
+        {"password": ""},
+    ],
+)
+def test_bootstrap_admin_rejects_empty_inputs(
+    runner: CliRunner, db_url: str, argv_kwargs: dict[str, str]
+) -> None:
+    result = runner.invoke(main, _bootstrap_admin_argv(**argv_kwargs))
+    assert result.exit_code != 0
+
+
+def test_bootstrap_admin_rolls_back_on_user_create_failure(
+    runner: CliRunner, db_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If user creation explodes mid-transaction, the new tenant must
+    not be committed — this is the architectural fix for finding #2,
+    expressed at the single-transaction grain."""
+
+    async def boom(self, *args, **kwargs):
+        msg = "simulated argon2 OOM"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("novamoc.domain.accounts._services.UserService.create", boom)
+    result = runner.invoke(main, _bootstrap_admin_argv())
+    assert result.exit_code != 0
+
+    tenants = asyncio.run(_all_tenants(db_url))
+    assert tenants == [], "tenant must roll back when later step fails"

--- a/tests/accounts/test_membership_service.py
+++ b/tests/accounts/test_membership_service.py
@@ -164,6 +164,56 @@ async def test_get_for_user_returns_membership(session: AsyncSession) -> None:
     assert found.tenant_id == tenant.id
 
 
+async def test_get_by_user_and_tenant_returns_none_when_absent(
+    session: AsyncSession,
+) -> None:
+    user = await _make_user(session, "naomi")
+    tenant = await _make_tenant(session, "Alpha")
+    svc = UserTenantMembershipService(session=session)
+
+    assert await svc.get_by_user_and_tenant(user.id, tenant.id) is None
+
+
+async def test_get_by_user_and_tenant_returns_existing_membership(
+    session: AsyncSession,
+) -> None:
+    """``bootstrap-admin`` (issue #128) leans on this to detect the
+    "user and tenant exist but membership never landed" partial-failure
+    case from a prior aborted run."""
+    user = await _make_user(session, "oscar")
+    tenant = await _make_tenant(session, "Alpha")
+    svc = UserTenantMembershipService(session=session)
+
+    created = await svc.create(
+        data={"user_id": user.id, "tenant_id": tenant.id},
+        auto_commit=False,
+    )
+    await session.flush()
+
+    found = await svc.get_by_user_and_tenant(user.id, tenant.id)
+    assert found is not None
+    assert (found.user_id, found.tenant_id) == (created.user_id, created.tenant_id)
+
+
+async def test_get_by_user_and_tenant_distinguishes_users(
+    session: AsyncSession,
+) -> None:
+    """Asymmetric arguments — looking up the *wrong* user against a
+    valid tenant must miss, not silently return some other user's row."""
+    alice = await _make_user(session, "patty")
+    bob = await _make_user(session, "quincy")
+    tenant = await _make_tenant(session, "Alpha")
+    svc = UserTenantMembershipService(session=session)
+
+    await svc.create(
+        data={"user_id": alice.id, "tenant_id": tenant.id},
+        auto_commit=False,
+    )
+    await session.flush()
+
+    assert await svc.get_by_user_and_tenant(bob.id, tenant.id) is None
+
+
 async def test_string_form_uuid_in_dict_payload_is_extracted(
     session: AsyncSession,
 ) -> None:

--- a/tests/accounts/test_tenant_service.py
+++ b/tests/accounts/test_tenant_service.py
@@ -1,0 +1,58 @@
+"""Service-layer tests for ``TenantService`` (ADR-020).
+
+Pins the helpers that the ``novamoc bootstrap-admin`` recipe (issue
+#128) leans on to recover from partial failure — primarily
+``get_by_display_name``, the lookup-or-create anchor for the
+Development tenant.
+
+Not tenant-scoped (the registry tables are not tenant-scoped), so the
+autouse ``tenant`` fixture is skipped on every test in this module.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from novamoc.domain.accounts._services import TenantService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+pytestmark = pytest.mark.no_tenant
+
+
+async def test_get_by_display_name_returns_none_when_absent(
+    session: AsyncSession,
+) -> None:
+    svc = TenantService(session=session)
+    assert await svc.get_by_display_name("Development") is None
+
+
+async def test_get_by_display_name_returns_existing_tenant(
+    session: AsyncSession,
+) -> None:
+    svc = TenantService(session=session)
+    created = await svc.create(data={"display_name": "Development"}, auto_commit=False)
+    await session.flush()
+
+    found = await svc.get_by_display_name("Development")
+    assert found is not None
+    assert found.id == created.id
+
+
+async def test_get_by_display_name_is_case_sensitive(session: AsyncSession) -> None:
+    """``display_name`` is verbatim — no folding, unlike usernames.
+
+    The bootstrap recipe always passes the same literal string, so a
+    case-insensitive match here would risk collapsing distinct
+    operator-created tenants.
+    """
+    svc = TenantService(session=session)
+    await svc.create(data={"display_name": "Development"}, auto_commit=False)
+    await session.flush()
+
+    assert await svc.get_by_display_name("development") is None
+    assert await svc.get_by_display_name("DEVELOPMENT") is None


### PR DESCRIPTION
## Summary

- Replace the three-CLI-call `bootstrap-dev` recipe with a single atomic `novamoc bootstrap-admin` command. Lookup-or-create at every step inside one transaction, so partial-failure recovery actually works.
- Closes both bugs from #128: orphan tenants from interrupted runs (#2) and tenant-less admin users when membership creation fails (#4).

## What changed

- `TenantService.get_by_display_name` — lookup-or-create anchor for the Development tenant.
- `UserTenantMembershipService.get_by_user_and_tenant` — detect the "user + tenant exist but membership never landed" partial-failure case.
- `novamoc bootstrap-admin --tenant-display-name --username --password` — single-transaction tenant + user + membership bootstrap. Refuses to silently relocate an admin already bound to a different tenant.
- `justfile` recipe collapses to `db-init` + one CLI call; the `awk` parse and the `user exists` three-way exit dance are gone.

## Test plan

- [x] `just check` passes end-to-end (lint, format, typecheck-py/js, coverage-py/js, ratchet, db-check).
- [x] New tests cover both partial-failure recovery modes: drop the membership row → re-run restores it without creating a new tenant; drop users + memberships → re-run reuses the prior tenant id.
- [x] New test pins the rollback semantics: forcing `UserService.create` to raise leaves zero rows in `tenants` (architectural fix expressed at the single-transaction grain).
- [x] New test pins the case-folding idempotence (`ADMIN` and `admin` resolve to the same user).
- [x] New test pins the "user already belongs to a different tenant" abort path.
- [x] End-to-end smoke against a temp SQLite confirms a second invocation prints `Reused tenant <same-uuid> ...` / `Reused user admin.` / `Reused membership ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)