### PR TITLE
docs(adr): ADR-003 Accepted (closes #139)

### DIFF
--- a/docs/adr/003-sqlite-wasm-client-storage.md
+++ b/docs/adr/003-sqlite-wasm-client-storage.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (2026-05-31)
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Flips ADR-003 (`docs/adr/003-sqlite-wasm-client-storage.md`) from `Proposed` to `Accepted (2026-05-31)`.
- Docs-only; the body of the ADR is unchanged per the project's ADR-immutability convention (only the `## Status` section is edited).
- Why now: Epic 1 (#138, "Local-first client data engine") is starting. Every Epic 1 sub-issue (E1.1 through E1.13) cites ADR-003's constraints — OPFS as the storage substrate, fail-closed on unsupported browser envelope (`FileSystemSyncAccessHandle` required), and the COOP/COEP requirement for `SharedArrayBuffer`. Until ADR-003 is Accepted, the rest of E1 is building on an unsigned contract.

## Sanity-check vs. current codebase

Per the issue, I re-read ADR-003's body against the current state of the code before accepting:

- COOP/COEP headers — configured in `src/js/web/vite.config.ts` (`Cross-Origin-Opener-Policy: same-origin`, `Cross-Origin-Embedder-Policy: require-corp`). Matches the ADR's "Consequences" section.
- Server-side projection / event-log / schema-change-log infrastructure — present (`src/py/novamoc/db/models/data/{_asset,_event,_maintenance_record}.py`, `src/py/novamoc/db/models/schema/{_asset_type,_change_log,_maintenance_record_type,_types}.py`). The ADR's "Context" assumption holds.

No substantive contradictions found between ADR-003 and the current code or any other Accepted ADR (006/007/009/011/012/013/014/019/020/021 spot-checked via citation in CLAUDE.md). No follow-up ADR-revision issue needed.

## Test plan

- [ ] `git diff main -- docs/adr/003-sqlite-wasm-client-storage.md` shows only the one-line Status change.
- [ ] No code changed; no test suite to run.

Closes #139.