### PR TITLE
feat(client): OPFS feature probe + blocking error UI

### DIFF
--- a/.coverage-ratchet.json
+++ b/.coverage-ratchet.json
@@ -1,7 +1,7 @@
 {
   "js": {
-    "branch": 50.0,
-    "line": 67.0
+    "branch": 51.0,
+    "line": 68.0
   },
   "python": {
     "branch": 87.0,

--- a/src/js/web/playwright.config.ts
+++ b/src/js/web/playwright.config.ts
@@ -24,6 +24,42 @@ const API_URL = `http://127.0.0.1:${API_PORT}`
 // defined. The cert is self-signed, hence ``ignoreHTTPSErrors`` below.
 const APP_URL = `https://127.0.0.1:${APP_PORT}`
 
+// ``E2E_SKIP_API=1`` runs only the Vite dev server. Some e2e tests
+// (e.g. the OPFS-probe blocking-UI test, issue #140) don't touch the
+// Python API at all — the layout's probe redirects to ``/unsupported``
+// before any backend call — and the existing in-memory API webServer
+// doesn't bootstrap Alembic (ADR-021), so it currently crashes at
+// startup. Until a proper test harness lands (see issue #81), opting
+// out keeps the SPA-only e2e tests runnable.
+const SKIP_API = process.env.E2E_SKIP_API === '1'
+
+const apiWebServer = {
+  command: `uv run litestar --app novamoc.asgi:create_app run --host 127.0.0.1 --port ${API_PORT}`,
+  cwd: '../../..',
+  env: {
+    NOVAMOC_DB_URL: 'sqlite+aiosqlite:///:memory:',
+    NOVAMOC_DB_STATIC_POOL: 'true',
+  },
+  url: `${API_URL}/openapi`,
+  reuseExistingServer: false,
+  timeout: 60_000,
+  stdout: 'pipe' as const,
+  stderr: 'pipe' as const,
+}
+
+const appWebServer = {
+  command: `npm run dev -- --port ${APP_PORT} --strictPort`,
+  env: {
+    NOVAMOC_API_URL: API_URL,
+  },
+  url: APP_URL,
+  ignoreHTTPSErrors: true,
+  reuseExistingServer: false,
+  timeout: 30_000,
+  stdout: 'pipe' as const,
+  stderr: 'pipe' as const,
+}
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: false,
@@ -36,32 +72,6 @@ export default defineConfig({
     trace: 'retain-on-failure',
     ignoreHTTPSErrors: true,
   },
-  webServer: [
-    {
-      command: `uv run litestar --app novamoc.asgi:create_app run --host 127.0.0.1 --port ${API_PORT}`,
-      cwd: '../../..',
-      env: {
-        NOVAMOC_DB_URL: 'sqlite+aiosqlite:///:memory:',
-        NOVAMOC_DB_STATIC_POOL: 'true',
-      },
-      url: `${API_URL}/openapi`,
-      reuseExistingServer: false,
-      timeout: 60_000,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-    {
-      command: `npm run dev -- --port ${APP_PORT} --strictPort`,
-      env: {
-        NOVAMOC_API_URL: API_URL,
-      },
-      url: APP_URL,
-      ignoreHTTPSErrors: true,
-      reuseExistingServer: false,
-      timeout: 30_000,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  ],
+  webServer: SKIP_API ? [appWebServer] : [apiWebServer, appWebServer],
   projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
 })

--- a/src/js/web/src/lib/db/probe.sync-handle.ts
+++ b/src/js/web/src/lib/db/probe.sync-handle.ts
@@ -1,0 +1,42 @@
+/**
+ * Main-thread driver for the worker-based sync-access-handle probe.
+ *
+ * `FileSystemSyncAccessHandle` is `[Exposed=DedicatedWorker]`, so the main
+ * thread can't detect it by inspecting prototypes — it has to ask a worker
+ * that actually tries to acquire one. See `./probe.worker`.
+ */
+
+const PROBE_TIMEOUT_MS = 5_000
+
+/** Whether a DedicatedWorker can acquire an OPFS sync access handle. */
+export async function checkSyncAccessHandle(): Promise<boolean> {
+  if (typeof Worker === 'undefined') return false
+
+  let worker: Worker
+  try {
+    worker = new Worker(new URL('./probe.worker.ts', import.meta.url), {
+      type: 'module',
+    })
+  } catch {
+    return false
+  }
+
+  try {
+    return await new Promise<boolean>((resolve) => {
+      // Resolve false if the worker never reports back — a hung probe must
+      // not block app boot.
+      const timer = setTimeout(() => resolve(false), PROBE_TIMEOUT_MS)
+      worker.onmessage = (event: MessageEvent<{ ok?: boolean }>) => {
+        clearTimeout(timer)
+        resolve(event.data?.ok === true)
+      }
+      worker.onerror = () => {
+        clearTimeout(timer)
+        resolve(false)
+      }
+      worker.postMessage('probe')
+    })
+  } finally {
+    worker.terminate()
+  }
+}

--- a/src/js/web/src/lib/db/probe.ts
+++ b/src/js/web/src/lib/db/probe.ts
@@ -1,0 +1,80 @@
+/**
+ * Startup feature probe for SQLite-WASM over OPFS (ADR-003).
+ *
+ * novaMOC is local-first: the client stores its full tenant dataset in
+ * SQLite-WASM persisted to the Origin Private File System. The OPFS
+ * VFS shipped by ``@sqlite.org/sqlite-wasm`` requires
+ * ``FileSystemSyncAccessHandle`` (Chrome 109+, Safari 17+, Firefox
+ * best-effort) AND cross-origin isolation (for SharedArrayBuffer).
+ *
+ * Per ADR-003 §Consequences, browsers missing any of those
+ * preconditions MUST get a blocking error rather than a silent
+ * in-memory fallback (which would lose data on tab close). This
+ * module exposes the probe; the layout consumes it and routes to the
+ * blocking error page on failure.
+ *
+ * The probe is intentionally a feature test, not UA sniffing — capability
+ * is what we actually care about, and UA strings are unreliable.
+ */
+
+/** The three failure modes the probe can report. */
+export type MissingFeature = 'opfs' | 'sync_handle' | 'cross_origin_isolation'
+
+/** Result of one probe run. */
+export type ProbeResult = { ok: true } | { ok: false; missing: MissingFeature }
+
+/**
+ * Probe the runtime for SQLite-WASM-over-OPFS support.
+ *
+ * Checks, in order:
+ * 1. ``navigator.storage.getDirectory`` exists (OPFS root accessible).
+ * 2. The root directory's prototype exposes
+ *    ``FileSystemSyncAccessHandle`` (sync access handle support).
+ * 3. ``crossOriginIsolated === true`` (SharedArrayBuffer prerequisite,
+ *    served via COOP/COEP headers — see ``vite.config.ts``).
+ *
+ * Returns on the first failure; the caller branches on ``missing`` to
+ * tell the user *what* they're missing.
+ */
+export async function probeOpfs(): Promise<ProbeResult> {
+  // 1. OPFS root accessible at all?
+  if (
+    typeof navigator === 'undefined' ||
+    !('storage' in navigator) ||
+    !navigator.storage ||
+    typeof (navigator.storage as StorageManager).getDirectory !== 'function'
+  ) {
+    return { ok: false, missing: 'opfs' }
+  }
+
+  // 2. ``FileSystemSyncAccessHandle`` available? We probe the directory
+  // handle's constructor prototype — that's where the sync-handle
+  // creator lives. ``createSyncAccessHandle`` would be the real method
+  // name, but the issue spec checks for the type name on the prototype;
+  // we honour the spec and tolerate either.
+  let root: FileSystemDirectoryHandle
+  try {
+    root = await navigator.storage.getDirectory()
+  } catch {
+    return { ok: false, missing: 'opfs' }
+  }
+  const proto = (root as unknown as { constructor: { prototype: object } })
+    .constructor.prototype
+  const hasSyncHandle =
+    'FileSystemSyncAccessHandle' in proto ||
+    'createSyncAccessHandle' in proto
+  if (!hasSyncHandle) {
+    return { ok: false, missing: 'sync_handle' }
+  }
+
+  // 3. Cross-origin isolated? Required for SharedArrayBuffer.
+  if (
+    typeof (globalThis as { crossOriginIsolated?: boolean })
+      .crossOriginIsolated !== 'boolean' ||
+    (globalThis as { crossOriginIsolated: boolean }).crossOriginIsolated !== true
+  ) {
+    return { ok: false, missing: 'cross_origin_isolation' }
+  }
+
+  return { ok: true }
+}

--- a/src/js/web/src/lib/db/probe.ts
+++ b/src/js/web/src/lib/db/probe.ts
@@ -2,20 +2,21 @@
  * Startup feature probe for SQLite-WASM over OPFS (ADR-003).
  *
  * novaMOC is local-first: the client stores its full tenant dataset in
- * SQLite-WASM persisted to the Origin Private File System. The OPFS
- * VFS shipped by ``@sqlite.org/sqlite-wasm`` requires
- * ``FileSystemSyncAccessHandle`` (Chrome 109+, Safari 17+, Firefox
- * best-effort) AND cross-origin isolation (for SharedArrayBuffer).
+ * SQLite-WASM persisted to the Origin Private File System. The OPFS VFS
+ * shipped by `@sqlite.org/sqlite-wasm` requires `FileSystemSyncAccessHandle`
+ * (Chrome 109+, Safari 17+, Firefox best-effort) AND cross-origin isolation
+ * (for SharedArrayBuffer).
  *
- * Per ADR-003 §Consequences, browsers missing any of those
- * preconditions MUST get a blocking error rather than a silent
- * in-memory fallback (which would lose data on tab close). This
- * module exposes the probe; the layout consumes it and routes to the
- * blocking error page on failure.
+ * Per ADR-003 §Consequences, browsers missing any precondition MUST get a
+ * blocking error rather than a silent in-memory fallback (which would lose
+ * data on tab close). This module exposes the probe; the layout consumes it
+ * and routes to the blocking error page on failure.
  *
- * The probe is intentionally a feature test, not UA sniffing — capability
- * is what we actually care about, and UA strings are unreliable.
+ * It's a feature test, not UA sniffing — capability is what matters and UA
+ * strings are unreliable.
  */
+
+import { checkSyncAccessHandle } from './probe.sync-handle'
 
 /** The three failure modes the probe can report. */
 export type MissingFeature = 'opfs' | 'sync_handle' | 'cross_origin_isolation'
@@ -27,53 +28,34 @@ export type ProbeResult = { ok: true } | { ok: false; missing: MissingFeature }
  * Probe the runtime for SQLite-WASM-over-OPFS support.
  *
  * Checks, in order:
- * 1. ``navigator.storage.getDirectory`` exists (OPFS root accessible).
- * 2. The root directory's prototype exposes
- *    ``FileSystemSyncAccessHandle`` (sync access handle support).
- * 3. ``crossOriginIsolated === true`` (SharedArrayBuffer prerequisite,
- *    served via COOP/COEP headers — see ``vite.config.ts``).
+ * 1. `navigator.storage.getDirectory` exists (OPFS root accessible).
+ * 2. `crossOriginIsolated === true` (SharedArrayBuffer prerequisite, served
+ *    via COOP/COEP — see `vite.config.ts`).
+ * 3. A worker can actually acquire a sync access handle. The interface is
+ *    `[Exposed=DedicatedWorker]`, so this is the only reliable detection —
+ *    inspecting prototypes on the main thread false-negatives in every
+ *    supporting browser. See `./probe.sync-handle`.
  *
- * Returns on the first failure; the caller branches on ``missing`` to
- * tell the user *what* they're missing.
+ * Returns on the first failure; the caller branches on `missing` to tell the
+ * user what they're missing. The worker probe runs last because it's the
+ * only async/expensive check.
  */
 export async function probeOpfs(): Promise<ProbeResult> {
-  // 1. OPFS root accessible at all?
   if (
     typeof navigator === 'undefined' ||
     !('storage' in navigator) ||
     !navigator.storage ||
-    typeof (navigator.storage as StorageManager).getDirectory !== 'function'
+    typeof navigator.storage.getDirectory !== 'function'
   ) {
     return { ok: false, missing: 'opfs' }
   }
 
-  // 2. ``FileSystemSyncAccessHandle`` available? We probe the directory
-  // handle's constructor prototype — that's where the sync-handle
-  // creator lives. ``createSyncAccessHandle`` would be the real method
-  // name, but the issue spec checks for the type name on the prototype;
-  // we honour the spec and tolerate either.
-  let root: FileSystemDirectoryHandle
-  try {
-    root = await navigator.storage.getDirectory()
-  } catch {
-    return { ok: false, missing: 'opfs' }
-  }
-  const proto = (root as unknown as { constructor: { prototype: object } })
-    .constructor.prototype
-  const hasSyncHandle =
-    'FileSystemSyncAccessHandle' in proto ||
-    'createSyncAccessHandle' in proto
-  if (!hasSyncHandle) {
-    return { ok: false, missing: 'sync_handle' }
-  }
-
-  // 3. Cross-origin isolated? Required for SharedArrayBuffer.
-  if (
-    typeof (globalThis as { crossOriginIsolated?: boolean })
-      .crossOriginIsolated !== 'boolean' ||
-    (globalThis as { crossOriginIsolated: boolean }).crossOriginIsolated !== true
-  ) {
+  if (globalThis.crossOriginIsolated !== true) {
     return { ok: false, missing: 'cross_origin_isolation' }
+  }
+
+  if (!(await checkSyncAccessHandle())) {
+    return { ok: false, missing: 'sync_handle' }
   }
 
   return { ok: true }

--- a/src/js/web/src/lib/db/probe.ts
+++ b/src/js/web/src/lib/db/probe.ts
@@ -25,7 +25,7 @@ export type MissingFeature = 'opfs' | 'sync_handle' | 'cross_origin_isolation'
 export type ProbeResult = { ok: true } | { ok: false; missing: MissingFeature }
 
 /**
- * Probe the runtime for SQLite-WASM-over-OPFS support.
+ * Probe the runtime for the OPFS preconditions SQLite-WASM needs.
  *
  * Checks, in order:
  * 1. `navigator.storage.getDirectory` exists (OPFS root accessible).

--- a/src/js/web/src/lib/db/probe.worker.ts
+++ b/src/js/web/src/lib/db/probe.worker.ts
@@ -24,7 +24,5 @@ async function canCreateSyncAccessHandle(): Promise<boolean> {
 }
 
 self.onmessage = async (): Promise<void> => {
-  ;(self as DedicatedWorkerGlobalScope).postMessage({
-    ok: await canCreateSyncAccessHandle(),
-  })
+  self.postMessage({ ok: await canCreateSyncAccessHandle() })
 }

--- a/src/js/web/src/lib/db/probe.worker.ts
+++ b/src/js/web/src/lib/db/probe.worker.ts
@@ -1,0 +1,30 @@
+/// <reference lib="webworker" />
+/**
+ * DedicatedWorker half of the OPFS sync-access-handle probe (ADR-003).
+ *
+ * `FileSystemSyncAccessHandle` is `[Exposed=DedicatedWorker]`, so support
+ * is invisible to the main thread — prototype inspection there reports a
+ * false negative in every supporting browser. We don't trust an interface
+ * name either: we open OPFS, create a temp file, actually acquire a sync
+ * access handle, then clean up. Only a real acquisition proves support.
+ */
+
+async function canCreateSyncAccessHandle(): Promise<boolean> {
+  try {
+    const root = await navigator.storage.getDirectory()
+    const name = `.novamoc-probe-${crypto.randomUUID()}`
+    const file = await root.getFileHandle(name, { create: true })
+    const handle = await file.createSyncAccessHandle()
+    handle.close()
+    await root.removeEntry(name)
+    return true
+  } catch {
+    return false
+  }
+}
+
+self.onmessage = async (): Promise<void> => {
+  ;(self as DedicatedWorkerGlobalScope).postMessage({
+    ok: await canCreateSyncAccessHandle(),
+  })
+}

--- a/src/js/web/src/routes/+layout.svelte
+++ b/src/js/web/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { onMount, setContext, type Snippet } from 'svelte'
 	import { goto } from '$app/navigation'
 	import { page } from '$app/state'
+	import { probeOpfs } from '$lib/db/probe'
 
 	type Principal = {
 		user: { id: string; username: string }
@@ -27,6 +28,24 @@
 	onMount(() => {
 		void (async () => {
 			try {
+				// OPFS feature probe (ADR-003) runs before anything else —
+				// if the browser can't run SQLite-WASM-over-OPFS we route
+				// to the blocking error page and never touch auth or data.
+				// On the ``/unsupported`` route itself we skip both the
+				// probe and the auth fetch — the user is already blocked
+				// from doing anything, and re-running the probe would
+				// either redirect-loop or hide the error page on a
+				// transient pass.
+				if (page.url.pathname === '/unsupported') {
+					return
+				}
+
+				const probe = await probeOpfs()
+				if (!probe.ok) {
+					await goto(`/unsupported?missing=${probe.missing}`, { replaceState: true })
+					return
+				}
+
 				const response = await fetch('/auth/me', { credentials: 'include' })
 				if (response.status === 200) {
 					principal = (await response.json()) as Principal

--- a/src/js/web/src/routes/unsupported/+page.svelte
+++ b/src/js/web/src/routes/unsupported/+page.svelte
@@ -11,31 +11,48 @@
 	 * generic "OPFS" message — better than blanking out.
 	 */
 
+	// `detail` is a sequence of text/code segments so API and header names
+	// render as <code> rather than literal backticks in Svelte interpolation.
+	type Segment = { text: string; code?: boolean }
 	type Reason = {
 		title: string
-		detail: string
+		detail: Segment[]
 	}
 
 	const REASONS: Record<MissingFeature, Reason> = {
 		opfs: {
 			title: 'Origin Private File System (OPFS) is not available.',
-			detail:
-				'novaMOC stores your data locally in OPFS. Your browser does not expose ' +
-				'``navigator.storage.getDirectory``, so the app cannot persist anything.',
+			detail: [
+				{ text: 'novaMOC stores your data locally in OPFS. Your browser does not expose ' },
+				{ text: 'navigator.storage.getDirectory', code: true },
+				{ text: ', so the app cannot persist anything.' },
+			],
 		},
 		sync_handle: {
 			title: 'OPFS synchronous access handles are not available.',
-			detail:
-				'novaMOC needs ``FileSystemSyncAccessHandle`` to run SQLite-WASM over OPFS. ' +
-				'Your browser exposes OPFS but not the synchronous variant required by the ' +
-				'SQLite VFS.',
+			detail: [
+				{ text: 'novaMOC needs ' },
+				{ text: 'FileSystemSyncAccessHandle', code: true },
+				{
+					text:
+						' to run SQLite-WASM over OPFS. Your browser exposes OPFS but not the ' +
+						'synchronous variant required by the SQLite VFS.',
+				},
+			],
 		},
 		cross_origin_isolation: {
 			title: 'This page is not cross-origin isolated.',
-			detail:
-				'novaMOC needs SharedArrayBuffer, which browsers gate on cross-origin isolation. ' +
-				'The page must be served with ``Cross-Origin-Opener-Policy: same-origin`` and ' +
-				'``Cross-Origin-Embedder-Policy: require-corp`` headers.',
+			detail: [
+				{
+					text:
+						'novaMOC needs SharedArrayBuffer, which browsers gate on cross-origin ' +
+						'isolation. The page must be served with ',
+				},
+				{ text: 'Cross-Origin-Opener-Policy: same-origin', code: true },
+				{ text: ' and ' },
+				{ text: 'Cross-Origin-Embedder-Policy: require-corp', code: true },
+				{ text: ' headers.' },
+			],
 		},
 	}
 
@@ -60,7 +77,7 @@
 		class="flex flex-col gap-2 rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900"
 	>
 		<p class="font-semibold" data-testid="missing-precondition">{reason.title}</p>
-		<p>{reason.detail}</p>
+		<p>{#each reason.detail as seg (seg.text)}{#if seg.code}<code class="rounded bg-red-100 px-1 font-mono text-[0.85em]">{seg.text}</code>{:else}{seg.text}{/if}{/each}</p>
 	</section>
 
 	<section class="flex flex-col gap-2 text-sm">

--- a/src/js/web/src/routes/unsupported/+page.svelte
+++ b/src/js/web/src/routes/unsupported/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { page } from '$app/state'
+	import type { MissingFeature } from '$lib/db/probe'
+
+	/**
+	 * Blocking error page rendered when ``probeOpfs`` fails (ADR-003).
+	 *
+	 * The probe reason rides in as ``?missing=<feature>`` so the page
+	 * survives a reload and a direct visit names the same precondition
+	 * the user originally hit. Unknown / missing values default to the
+	 * generic "OPFS" message — better than blanking out.
+	 */
+
+	type Reason = {
+		title: string
+		detail: string
+	}
+
+	const REASONS: Record<MissingFeature, Reason> = {
+		opfs: {
+			title: 'Origin Private File System (OPFS) is not available.',
+			detail:
+				'novaMOC stores your data locally in OPFS. Your browser does not expose ' +
+				'``navigator.storage.getDirectory``, so the app cannot persist anything.',
+		},
+		sync_handle: {
+			title: 'OPFS synchronous access handles are not available.',
+			detail:
+				'novaMOC needs ``FileSystemSyncAccessHandle`` to run SQLite-WASM over OPFS. ' +
+				'Your browser exposes OPFS but not the synchronous variant required by the ' +
+				'SQLite VFS.',
+		},
+		cross_origin_isolation: {
+			title: 'This page is not cross-origin isolated.',
+			detail:
+				'novaMOC needs SharedArrayBuffer, which browsers gate on cross-origin isolation. ' +
+				'The page must be served with ``Cross-Origin-Opener-Policy: same-origin`` and ' +
+				'``Cross-Origin-Embedder-Policy: require-corp`` headers.',
+		},
+	}
+
+	function isMissingFeature(value: string | null): value is MissingFeature {
+		return value === 'opfs' || value === 'sync_handle' || value === 'cross_origin_isolation'
+	}
+
+	const param = page.url.searchParams.get('missing')
+	const missing: MissingFeature = isMissingFeature(param) ? param : 'opfs'
+	const reason = $derived(REASONS[missing])
+</script>
+
+<svelte:head>
+	<title>Unsupported browser — novaMOC</title>
+</svelte:head>
+
+<main class="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-6 px-6 py-12">
+	<h1 class="text-2xl font-semibold">novaMOC cannot run in this browser.</h1>
+
+	<section
+		role="alert"
+		class="flex flex-col gap-2 rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900"
+	>
+		<p class="font-semibold" data-testid="missing-precondition">{reason.title}</p>
+		<p>{reason.detail}</p>
+	</section>
+
+	<section class="flex flex-col gap-2 text-sm">
+		<h2 class="text-base font-semibold">Supported browsers</h2>
+		<ul class="ml-5 list-disc">
+			<li>Chrome / Edge 109 or later (January 2023).</li>
+			<li>Safari 17 or later (September 2023) on macOS and iOS.</li>
+			<li>Firefox is best-effort; we retest on each SQLite-WASM release.</li>
+		</ul>
+		<p class="text-gray-700">
+			Please reopen novaMOC in one of the supported browsers. Until then the app cannot load
+			your data.
+		</p>
+	</section>
+</main>

--- a/src/js/web/tests/component/probe.sync-handle.test.ts
+++ b/src/js/web/tests/component/probe.sync-handle.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the main-thread worker driver `checkSyncAccessHandle`.
+ *
+ * The worker itself does real OPFS I/O and only runs in a browser (covered
+ * by the Playwright e2e). Here we stub the `Worker` global to drive the
+ * driver's message/error/timeout handling deterministically.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { checkSyncAccessHandle } from '../../src/lib/db/probe.sync-handle'
+
+type Behavior = 'ok' | 'fail' | 'error' | 'silent' | 'nodata'
+
+class FakeWorker {
+  onmessage: ((e: { data: unknown }) => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+  static behavior: Behavior = 'ok'
+  static terminated = 0
+  postMessage(): void {
+    queueMicrotask(() => {
+      if (FakeWorker.behavior === 'ok') this.onmessage?.({ data: { ok: true } })
+      else if (FakeWorker.behavior === 'fail') this.onmessage?.({ data: { ok: false } })
+      else if (FakeWorker.behavior === 'nodata') this.onmessage?.({ data: undefined })
+      else if (FakeWorker.behavior === 'error') this.onerror?.(new Error('boom'))
+      // 'silent': never responds — exercises the timeout path.
+    })
+  }
+  terminate(): void {
+    FakeWorker.terminated += 1
+  }
+}
+
+const g = globalThis as typeof globalThis & { Worker?: unknown }
+const originalWorker = Object.getOwnPropertyDescriptor(g, 'Worker')
+
+beforeEach(() => {
+  FakeWorker.behavior = 'ok'
+  FakeWorker.terminated = 0
+  Object.defineProperty(g, 'Worker', { value: FakeWorker, configurable: true, writable: true })
+})
+
+afterEach(() => {
+  if (originalWorker) Object.defineProperty(g, 'Worker', originalWorker)
+  else delete (g as Record<string, unknown>).Worker
+  vi.useRealTimers()
+})
+
+describe('checkSyncAccessHandle', () => {
+  it('returns false when Worker is unavailable', async () => {
+    delete (g as Record<string, unknown>).Worker
+    expect(await checkSyncAccessHandle()).toBe(false)
+  })
+
+  it('returns false when the Worker constructor throws', async () => {
+    Object.defineProperty(g, 'Worker', {
+      value: class {
+        constructor() {
+          throw new Error('worker construction failed')
+        }
+      },
+      configurable: true,
+      writable: true,
+    })
+    expect(await checkSyncAccessHandle()).toBe(false)
+  })
+
+  it('returns true when the worker reports ok', async () => {
+    FakeWorker.behavior = 'ok'
+    expect(await checkSyncAccessHandle()).toBe(true)
+    expect(FakeWorker.terminated).toBe(1)
+  })
+
+  it('returns false when the worker reports failure', async () => {
+    FakeWorker.behavior = 'fail'
+    expect(await checkSyncAccessHandle()).toBe(false)
+    expect(FakeWorker.terminated).toBe(1)
+  })
+
+  it('returns false when the worker posts a message without a payload', async () => {
+    FakeWorker.behavior = 'nodata'
+    expect(await checkSyncAccessHandle()).toBe(false)
+  })
+
+  it('returns false when the worker errors', async () => {
+    FakeWorker.behavior = 'error'
+    expect(await checkSyncAccessHandle()).toBe(false)
+    expect(FakeWorker.terminated).toBe(1)
+  })
+
+  it('returns false (and terminates) when the worker never responds', async () => {
+    vi.useFakeTimers()
+    FakeWorker.behavior = 'silent'
+    const pending = checkSyncAccessHandle()
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(await pending).toBe(false)
+    expect(FakeWorker.terminated).toBe(1)
+  })
+})

--- a/src/js/web/tests/component/probe.sync-handle.test.ts
+++ b/src/js/web/tests/component/probe.sync-handle.test.ts
@@ -10,6 +10,9 @@ import { checkSyncAccessHandle } from '../../src/lib/db/probe.sync-handle'
 
 type Behavior = 'ok' | 'fail' | 'error' | 'silent' | 'nodata'
 
+// The driver constructs the worker internally, so the test can't pass
+// per-instance config — behavior is set externally before each call and
+// reset in beforeEach. Safe because vitest runs a file's tests serially.
 class FakeWorker {
   onmessage: ((e: { data: unknown }) => void) | null = null
   onerror: ((e: unknown) => void) | null = null

--- a/src/js/web/tests/component/probe.test.ts
+++ b/src/js/web/tests/component/probe.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for ``probeOpfs`` — the startup feature probe that gates
+ * the SPA on browsers capable of running SQLite-WASM over OPFS with
+ * ``FileSystemSyncAccessHandle`` (ADR-003). The probe MUST fail closed
+ * — if any of OPFS / sync-access-handle / cross-origin isolation is
+ * unavailable, the layout routes to a blocking error page rather than
+ * silently falling back to an in-memory DB.
+ *
+ * The tests stub the relevant globals (``navigator.storage``,
+ * ``crossOriginIsolated``) directly on ``globalThis`` because the probe
+ * reads them by name; jsdom ships none of them.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { probeOpfs } from '../../src/lib/db/probe'
+
+type MutableGlobal = typeof globalThis & {
+  navigator: Navigator
+  crossOriginIsolated?: boolean
+}
+
+const g = globalThis as MutableGlobal
+
+// We mutate ``navigator`` and ``crossOriginIsolated`` per-test, so capture
+// the originals up front and restore them after each test rather than
+// relying on jsdom's default reset.
+const originalNavigator = g.navigator
+const originalCrossOriginIsolated = Object.getOwnPropertyDescriptor(
+  g,
+  'crossOriginIsolated',
+)
+
+function setNavigator(nav: Partial<Navigator>): void {
+  Object.defineProperty(g, 'navigator', {
+    value: nav,
+    configurable: true,
+    writable: true,
+  })
+}
+
+function setCrossOriginIsolated(value: boolean): void {
+  Object.defineProperty(g, 'crossOriginIsolated', {
+    value,
+    configurable: true,
+    writable: true,
+  })
+}
+
+/**
+ * Build a fake ``navigator.storage`` whose root directory's prototype
+ * has (or lacks) ``FileSystemSyncAccessHandle``. The probe inspects the
+ * directory handle's constructor prototype to decide whether the sync
+ * variant is supported.
+ */
+function fakeStorage(syncHandleSupported: boolean): { getDirectory: () => Promise<unknown> } {
+  // Build a prototype with or without the sync-handle marker. The probe
+  // checks ``'FileSystemSyncAccessHandle' in <root>.constructor.prototype``;
+  // wiring the marker onto the constructor's prototype mirrors how a real
+  // ``FileSystemDirectoryHandle`` would expose ``createSyncAccessHandle``.
+  function Dir(this: unknown): void {}
+  if (syncHandleSupported) {
+    ;(Dir.prototype as Record<string, unknown>).FileSystemSyncAccessHandle =
+      function () {}
+  }
+  const root = Object.create(Dir.prototype as object) as object
+  return {
+    getDirectory: () => Promise.resolve(root),
+  }
+}
+
+afterEach(() => {
+  Object.defineProperty(g, 'navigator', {
+    value: originalNavigator,
+    configurable: true,
+    writable: true,
+  })
+  if (originalCrossOriginIsolated) {
+    Object.defineProperty(g, 'crossOriginIsolated', originalCrossOriginIsolated)
+  } else {
+    delete (g as Record<string, unknown>).crossOriginIsolated
+  }
+})
+
+describe('probeOpfs', () => {
+  describe('OPFS missing', () => {
+    it('fails with missing="opfs" when navigator has no storage', async () => {
+      setNavigator({} as Navigator)
+      setCrossOriginIsolated(true)
+
+      const result = await probeOpfs()
+      expect(result).toEqual({ ok: false, missing: 'opfs' })
+    })
+
+    it('fails with missing="opfs" when navigator.storage lacks getDirectory', async () => {
+      setNavigator({ storage: {} as StorageManager } as Navigator)
+      setCrossOriginIsolated(true)
+
+      const result = await probeOpfs()
+      expect(result).toEqual({ ok: false, missing: 'opfs' })
+    })
+  })
+
+  describe('sync access handle missing', () => {
+    it('fails with missing="sync_handle" when the directory prototype lacks FileSystemSyncAccessHandle', async () => {
+      setNavigator({
+        storage: fakeStorage(false) as unknown as StorageManager,
+      } as Navigator)
+      setCrossOriginIsolated(true)
+
+      const result = await probeOpfs()
+      expect(result).toEqual({ ok: false, missing: 'sync_handle' })
+    })
+  })
+
+  describe('cross-origin isolation missing', () => {
+    it('fails with missing="cross_origin_isolation" when crossOriginIsolated is false', async () => {
+      setNavigator({
+        storage: fakeStorage(true) as unknown as StorageManager,
+      } as Navigator)
+      setCrossOriginIsolated(false)
+
+      const result = await probeOpfs()
+      expect(result).toEqual({ ok: false, missing: 'cross_origin_isolation' })
+    })
+
+    it('fails with missing="cross_origin_isolation" when crossOriginIsolated is undefined', async () => {
+      setNavigator({
+        storage: fakeStorage(true) as unknown as StorageManager,
+      } as Navigator)
+      // Explicitly delete the global so the probe sees ``undefined``.
+      delete (g as Record<string, unknown>).crossOriginIsolated
+
+      const result = await probeOpfs()
+      expect(result).toEqual({ ok: false, missing: 'cross_origin_isolation' })
+    })
+  })
+
+  describe('success', () => {
+    it('returns ok=true when all three preconditions are met', async () => {
+      setNavigator({
+        storage: fakeStorage(true) as unknown as StorageManager,
+      } as Navigator)
+      setCrossOriginIsolated(true)
+
+      const result = await probeOpfs()
+      expect(result).toEqual({ ok: true })
+    })
+  })
+})

--- a/src/js/web/tests/component/probe.test.ts
+++ b/src/js/web/tests/component/probe.test.ts
@@ -1,16 +1,22 @@
 /**
- * Unit tests for ``probeOpfs`` — the startup feature probe that gates
- * the SPA on browsers capable of running SQLite-WASM over OPFS with
- * ``FileSystemSyncAccessHandle`` (ADR-003). The probe MUST fail closed
- * — if any of OPFS / sync-access-handle / cross-origin isolation is
+ * Unit tests for `probeOpfs` orchestration (ADR-003). The probe must fail
+ * closed — if OPFS, cross-origin isolation, or the sync access handle is
  * unavailable, the layout routes to a blocking error page rather than
  * silently falling back to an in-memory DB.
  *
- * The tests stub the relevant globals (``navigator.storage``,
- * ``crossOriginIsolated``) directly on ``globalThis`` because the probe
- * reads them by name; jsdom ships none of them.
+ * The sync-handle check is genuinely only observable in a DedicatedWorker
+ * (the interface is `[Exposed=DedicatedWorker]`), so it can't be exercised
+ * in jsdom. Here we mock that boundary (`./probe.sync-handle`) to drive the
+ * orchestration deterministically; the real worker path is covered by the
+ * Playwright e2e (api-smoke proves the happy path in a real browser).
  */
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { checkSyncAccessHandle } = vi.hoisted(() => ({
+  checkSyncAccessHandle: vi.fn<() => Promise<boolean>>(),
+}))
+vi.mock('../../src/lib/db/probe.sync-handle', () => ({ checkSyncAccessHandle }))
+
 import { probeOpfs } from '../../src/lib/db/probe'
 
 type MutableGlobal = typeof globalThis & {
@@ -20,9 +26,6 @@ type MutableGlobal = typeof globalThis & {
 
 const g = globalThis as MutableGlobal
 
-// We mutate ``navigator`` and ``crossOriginIsolated`` per-test, so capture
-// the originals up front and restore them after each test rather than
-// relying on jsdom's default reset.
 const originalNavigator = g.navigator
 const originalCrossOriginIsolated = Object.getOwnPropertyDescriptor(
   g,
@@ -45,27 +48,16 @@ function setCrossOriginIsolated(value: boolean): void {
   })
 }
 
-/**
- * Build a fake ``navigator.storage`` whose root directory's prototype
- * has (or lacks) ``FileSystemSyncAccessHandle``. The probe inspects the
- * directory handle's constructor prototype to decide whether the sync
- * variant is supported.
- */
-function fakeStorage(syncHandleSupported: boolean): { getDirectory: () => Promise<unknown> } {
-  // Build a prototype with or without the sync-handle marker. The probe
-  // checks ``'FileSystemSyncAccessHandle' in <root>.constructor.prototype``;
-  // wiring the marker onto the constructor's prototype mirrors how a real
-  // ``FileSystemDirectoryHandle`` would expose ``createSyncAccessHandle``.
-  function Dir(this: unknown): void {}
-  if (syncHandleSupported) {
-    ;(Dir.prototype as Record<string, unknown>).FileSystemSyncAccessHandle =
-      function () {}
-  }
-  const root = Object.create(Dir.prototype as object) as object
+/** A navigator whose OPFS root is reachable (getDirectory is callable). */
+function navigatorWithOpfs(): Navigator {
   return {
-    getDirectory: () => Promise.resolve(root),
-  }
+    storage: { getDirectory: () => Promise.resolve({}) } as unknown as StorageManager,
+  } as Navigator
 }
+
+beforeEach(() => {
+  checkSyncAccessHandle.mockReset()
+})
 
 afterEach(() => {
   Object.defineProperty(g, 'navigator', {
@@ -82,67 +74,74 @@ afterEach(() => {
 
 describe('probeOpfs', () => {
   describe('OPFS missing', () => {
+    it('fails with missing="opfs" when navigator is undefined', async () => {
+      delete (g as Record<string, unknown>).navigator
+      setCrossOriginIsolated(true)
+
+      expect(await probeOpfs()).toEqual({ ok: false, missing: 'opfs' })
+      expect(checkSyncAccessHandle).not.toHaveBeenCalled()
+    })
+
     it('fails with missing="opfs" when navigator has no storage', async () => {
       setNavigator({} as Navigator)
       setCrossOriginIsolated(true)
 
-      const result = await probeOpfs()
-      expect(result).toEqual({ ok: false, missing: 'opfs' })
+      expect(await probeOpfs()).toEqual({ ok: false, missing: 'opfs' })
+      expect(checkSyncAccessHandle).not.toHaveBeenCalled()
     })
 
     it('fails with missing="opfs" when navigator.storage lacks getDirectory', async () => {
       setNavigator({ storage: {} as StorageManager } as Navigator)
       setCrossOriginIsolated(true)
 
-      const result = await probeOpfs()
-      expect(result).toEqual({ ok: false, missing: 'opfs' })
-    })
-  })
-
-  describe('sync access handle missing', () => {
-    it('fails with missing="sync_handle" when the directory prototype lacks FileSystemSyncAccessHandle', async () => {
-      setNavigator({
-        storage: fakeStorage(false) as unknown as StorageManager,
-      } as Navigator)
-      setCrossOriginIsolated(true)
-
-      const result = await probeOpfs()
-      expect(result).toEqual({ ok: false, missing: 'sync_handle' })
+      expect(await probeOpfs()).toEqual({ ok: false, missing: 'opfs' })
+      expect(checkSyncAccessHandle).not.toHaveBeenCalled()
     })
   })
 
   describe('cross-origin isolation missing', () => {
     it('fails with missing="cross_origin_isolation" when crossOriginIsolated is false', async () => {
-      setNavigator({
-        storage: fakeStorage(true) as unknown as StorageManager,
-      } as Navigator)
+      setNavigator(navigatorWithOpfs())
       setCrossOriginIsolated(false)
 
-      const result = await probeOpfs()
-      expect(result).toEqual({ ok: false, missing: 'cross_origin_isolation' })
+      expect(await probeOpfs()).toEqual({
+        ok: false,
+        missing: 'cross_origin_isolation',
+      })
+      // No point spawning the worker if SharedArrayBuffer is unavailable.
+      expect(checkSyncAccessHandle).not.toHaveBeenCalled()
     })
 
     it('fails with missing="cross_origin_isolation" when crossOriginIsolated is undefined', async () => {
-      setNavigator({
-        storage: fakeStorage(true) as unknown as StorageManager,
-      } as Navigator)
-      // Explicitly delete the global so the probe sees ``undefined``.
+      setNavigator(navigatorWithOpfs())
       delete (g as Record<string, unknown>).crossOriginIsolated
 
-      const result = await probeOpfs()
-      expect(result).toEqual({ ok: false, missing: 'cross_origin_isolation' })
+      expect(await probeOpfs()).toEqual({
+        ok: false,
+        missing: 'cross_origin_isolation',
+      })
+      expect(checkSyncAccessHandle).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sync access handle missing', () => {
+    it('fails with missing="sync_handle" when the worker cannot acquire one', async () => {
+      setNavigator(navigatorWithOpfs())
+      setCrossOriginIsolated(true)
+      checkSyncAccessHandle.mockResolvedValue(false)
+
+      expect(await probeOpfs()).toEqual({ ok: false, missing: 'sync_handle' })
+      expect(checkSyncAccessHandle).toHaveBeenCalledOnce()
     })
   })
 
   describe('success', () => {
     it('returns ok=true when all three preconditions are met', async () => {
-      setNavigator({
-        storage: fakeStorage(true) as unknown as StorageManager,
-      } as Navigator)
+      setNavigator(navigatorWithOpfs())
       setCrossOriginIsolated(true)
+      checkSyncAccessHandle.mockResolvedValue(true)
 
-      const result = await probeOpfs()
-      expect(result).toEqual({ ok: true })
+      expect(await probeOpfs()).toEqual({ ok: true })
     })
   })
 })

--- a/src/js/web/tests/component/unsupported.test.ts
+++ b/src/js/web/tests/component/unsupported.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the ``/unsupported`` blocking error page (issue
+ * #140 / ADR-003). The page receives the failed precondition as
+ * ``?missing=<feature>`` and must name BOTH the precondition AND
+ * the supported browsers; missing or unknown values fall back to the
+ * generic OPFS message rather than blanking out.
+ *
+ * Mocks ``$app/state`` so we can drive the ``page.url.searchParams``
+ * the component reads without booting a real router.
+ */
+import { render, screen } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mocked first so the import order matches the component's module graph.
+vi.mock('$app/state', () => {
+  let _url = new URL('https://example.com/unsupported')
+  return {
+    page: {
+      get url() {
+        return _url
+      },
+    },
+    __setUrl(href: string) {
+      _url = new URL(href)
+    },
+  }
+})
+
+// Re-import the mock module so we can drive the URL from the test body.
+const appState = (await import('$app/state')) as unknown as {
+  __setUrl: (href: string) => void
+}
+
+import UnsupportedPage from '../../src/routes/unsupported/+page.svelte'
+
+describe('unsupported page', () => {
+  it('names the OPFS precondition when missing=opfs', async () => {
+    appState.__setUrl('https://example.com/unsupported?missing=opfs')
+    render(UnsupportedPage)
+
+    expect(screen.getByTestId('missing-precondition')).toHaveTextContent(
+      /Origin Private File System/,
+    )
+    expect(screen.getByText('Chrome / Edge 109 or later (January 2023).')).toBeInTheDocument()
+    expect(screen.getByText(/Safari 17 or later/)).toBeInTheDocument()
+    expect(screen.getByText(/Firefox is best-effort/)).toBeInTheDocument()
+  })
+
+  it('names the sync-handle precondition when missing=sync_handle', async () => {
+    appState.__setUrl('https://example.com/unsupported?missing=sync_handle')
+    render(UnsupportedPage)
+
+    expect(screen.getByTestId('missing-precondition')).toHaveTextContent(
+      /synchronous access handles/,
+    )
+  })
+
+  it('names the cross-origin isolation precondition when missing=cross_origin_isolation', async () => {
+    appState.__setUrl(
+      'https://example.com/unsupported?missing=cross_origin_isolation',
+    )
+    render(UnsupportedPage)
+
+    expect(screen.getByTestId('missing-precondition')).toHaveTextContent(
+      /cross-origin isolated/,
+    )
+  })
+
+  it('falls back to the generic OPFS message when missing is absent', async () => {
+    appState.__setUrl('https://example.com/unsupported')
+    render(UnsupportedPage)
+
+    expect(screen.getByTestId('missing-precondition')).toHaveTextContent(
+      /Origin Private File System/,
+    )
+  })
+
+  it('falls back to the generic OPFS message when missing is unknown', async () => {
+    appState.__setUrl('https://example.com/unsupported?missing=bogus')
+    render(UnsupportedPage)
+
+    expect(screen.getByTestId('missing-precondition')).toHaveTextContent(
+      /Origin Private File System/,
+    )
+  })
+
+  it('always lists supported browsers', async () => {
+    appState.__setUrl('https://example.com/unsupported?missing=cross_origin_isolation')
+    render(UnsupportedPage)
+
+    expect(screen.getByText(/Chrome \/ Edge 109/)).toBeInTheDocument()
+    expect(screen.getByText(/Safari 17/)).toBeInTheDocument()
+    expect(screen.getByText(/Firefox/)).toBeInTheDocument()
+  })
+})

--- a/src/js/web/tests/e2e/unsupported.spec.ts
+++ b/src/js/web/tests/e2e/unsupported.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Playwright e2e for the OPFS feature probe (ADR-003) and the
+ * blocking error UI it routes to.
+ *
+ * Two cases:
+ *
+ * 1. Cross-origin isolation missing — we override
+ *    ``window.crossOriginIsolated`` to ``false`` via ``addInitScript``
+ *    before navigation. The probe in ``$lib/db/probe`` runs at layout
+ *    mount, sees the override, and routes to ``/unsupported?missing=
+ *    cross_origin_isolation``. The blocking UI must surface BOTH the
+ *    failed precondition AND the supported-browser list (acceptance
+ *    criterion).
+ *
+ * 2. Direct visit to ``/unsupported`` with a query param renders the
+ *    matching reason. Confirms a reload / bookmark of the error URL
+ *    still names the right precondition.
+ *
+ * COOP/COEP are set on the Vite dev server (see ``vite.config.ts``),
+ * so ``crossOriginIsolated`` is genuinely ``true`` in a vanilla browser
+ * context. The override is the cheapest reliable way to drive the
+ * probe into its failure branch without spinning a second server with
+ * different headers just for the test.
+ */
+
+import { expect, test } from '@playwright/test'
+
+test('blocking UI renders when an OPFS precondition is missing', async ({ page }) => {
+  // Spoof ``window.crossOriginIsolated`` to ``false`` for every
+  // navigation in this page context, AND null out
+  // ``navigator.storage`` so the very first precondition (OPFS) trips.
+  // We don't need to drive the probe into one specific branch — the
+  // acceptance criterion is that the blocking UI renders for an
+  // unsupported environment AND names BOTH the failed precondition
+  // and the supported browsers (issue #140).
+  //
+  // We pick the OPFS branch by deleting ``navigator.storage`` because
+  // it's the cheapest to override and works identically across
+  // browsers — the other two require runtime introspection of the
+  // page context.
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      get: () => undefined,
+    })
+    Object.defineProperty(window, 'crossOriginIsolated', {
+      configurable: true,
+      get: () => false,
+    })
+  })
+
+  await page.goto('/')
+
+  // Layout redirects to ``/unsupported?missing=...``. The exact reason
+  // depends on which check trips first; we assert on the URL path and
+  // the rendered content rather than pinning a specific ``missing=``.
+  await page.waitForURL(/\/unsupported\?missing=/, { timeout: 10_000 })
+
+  // The failed precondition is named.
+  await expect(page.getByTestId('missing-precondition')).toBeVisible()
+
+  // Supported browsers are listed (acceptance criterion).
+  await expect(page.getByText('Chrome / Edge 109 or later')).toBeVisible()
+  await expect(page.getByText('Safari 17 or later')).toBeVisible()
+  await expect(page.getByText('Firefox is best-effort')).toBeVisible()
+})
+
+test('direct visit to /unsupported with missing=opfs names the OPFS precondition', async ({
+  page,
+}) => {
+  await page.goto('/unsupported?missing=opfs')
+
+  await expect(page.getByTestId('missing-precondition')).toContainText(
+    'Origin Private File System',
+  )
+  await expect(page.getByText('Chrome / Edge 109 or later')).toBeVisible()
+})
+
+test('direct visit to /unsupported with missing=sync_handle names the sync-handle precondition', async ({
+  page,
+}) => {
+  await page.goto('/unsupported?missing=sync_handle')
+
+  await expect(page.getByTestId('missing-precondition')).toContainText(
+    'synchronous access handles',
+  )
+})

--- a/src/js/web/vite.config.ts
+++ b/src/js/web/vite.config.ts
@@ -12,6 +12,9 @@ const crossOriginIsolation: Plugin = {
   name: 'novamoc-cross-origin-isolation',
   configureServer(server) {
     server.middlewares.use((_req, res, next) => {
+      // Applied to every response; fine for an all-same-origin SPA. If
+      // cross-origin assets are introduced later they'll need a
+      // Cross-Origin-Resource-Policy header to load under COEP.
       res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
       res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
       next()

--- a/src/js/web/vite.config.ts
+++ b/src/js/web/vite.config.ts
@@ -1,7 +1,23 @@
+import type { Plugin } from 'vite'
 import { defineConfig } from 'vitest/config'
 import { sveltekit } from '@sveltejs/kit/vite'
 import tailwindcss from '@tailwindcss/vite'
 import basicSsl from '@vitejs/plugin-basic-ssl'
+
+// Vite's `server.headers` reach assets but not the SvelteKit-rendered HTML
+// document, so `crossOriginIsolated` (and thus SharedArrayBuffer / the OPFS
+// VFS, ADR-003) stays off. A dev-server middleware sets COOP/COEP on every
+// response, document included. In prod the static host sets them (ADR-021).
+const crossOriginIsolation: Plugin = {
+  name: 'novamoc-cross-origin-isolation',
+  configureServer(server) {
+    server.middlewares.use((_req, res, next) => {
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+      res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+      next()
+    })
+  },
+}
 
 // In dev, forward the API surface to the Python server. The SPA always
 // uses relative paths so production deployments can serve client and API
@@ -23,7 +39,12 @@ const API_PROXY_PATHS = ['/auth', '/schema', '/events', '/problems', '/openapi']
 // have to be set by whoever serves the bundle — in dev that's Vite, in
 // prod that's whatever HTTP server hosts ``build/`` (see ADR-021).
 export default defineConfig({
-  plugins: [...(process.env.NOVAMOC_NO_HTTPS ? [] : [basicSsl()]), tailwindcss(), sveltekit()],
+  plugins: [
+    ...(process.env.NOVAMOC_NO_HTTPS ? [] : [basicSsl()]),
+    crossOriginIsolation,
+    tailwindcss(),
+    sveltekit(),
+  ],
   // Under Vitest, force Svelte's ``browser`` export condition so we get
   // the client build rather than the SSR build (which throws
   // ``lifecycle_function_unavailable`` on ``mount``). Set conditionally so
@@ -34,10 +55,6 @@ export default defineConfig({
     ? { resolve: { conditions: ['browser'] } }
     : {}),
   server: {
-    headers: {
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Cross-Origin-Embedder-Policy': 'require-corp',
-    },
     proxy: Object.fromEntries(
       API_PROXY_PATHS.map((p) => [p, { target: API_PROXY_TARGET, changeOrigin: false }]),
     ),
@@ -53,7 +70,14 @@ export default defineConfig({
       reporter: ['text', 'html', 'json-summary'],
       reportsDirectory: 'coverage',
       include: ['src/**/*.{ts,svelte}'],
-      exclude: ['src/**/*.d.ts', 'tests/**', 'tests/e2e/**'],
+      exclude: [
+        'src/**/*.d.ts',
+        'tests/**',
+        'tests/e2e/**',
+        // The worker body does real OPFS I/O in DedicatedWorker scope —
+        // not reachable in jsdom; covered by the Playwright e2e instead.
+        'src/lib/db/probe.worker.ts',
+      ],
       // No `thresholds:` block — the ratchet does the gating. Setting a
       // threshold here would either duplicate the ratchet's role or fight it.
     },


### PR DESCRIPTION
## Summary

Implements **E1.1** (OPFS feature probe + blocking error UI) of Epic 1
(#138 / #140), per ADR-003 §Consequences. The client refuses to run —
with a blocking error naming the missing precondition — on browsers that
can't back SQLite-WASM with an OPFS sync access handle, rather than
silently falling back to an in-memory DB that loses data on tab close.

- `$lib/db/probe.ts::probeOpfs()` returns
  `{ok:true} | {ok:false, missing:'opfs'|'sync_handle'|'cross_origin_isolation'}`.
  It checks, in order: OPFS root reachable (main thread), `crossOriginIsolated`
  (main thread), then whether a worker can actually acquire a sync access
  handle.
- **Sync-handle detection runs in a worker.** `FileSystemSyncAccessHandle`
  is `[Exposed=DedicatedWorker]` — invisible to the main thread — so
  inspecting prototypes there false-negatives in *every* supporting
  browser. `probe.worker.ts` opens OPFS and acquires (then releases) a
  real handle; `probe.sync-handle.ts` drives it with a timeout.
- **COOP/COEP now reach the document.** Vite's `server.headers` apply to
  assets but not the SvelteKit-rendered HTML, so `crossOriginIsolated` was
  always `false` (latent until this probe needed it). A dev-server
  middleware in `vite.config.ts` sets them on every response; the static
  host owns this in prod (ADR-021).
- Root `+layout.svelte` runs the probe before any auth fetch and
  `goto`s `/unsupported?missing=<reason>` on failure; on `/unsupported`
  itself it skips probe + auth to avoid redirect loops.
- `src/routes/unsupported/+page.svelte` names the failed precondition AND
  lists supported browsers (Chrome 109+, Safari 17+, Firefox best-effort).

## Tests

- `probe.test.ts` — orchestration, mocking the worker boundary (no more
  circular global-prototype mocks).
- `probe.sync-handle.test.ts` — the worker driver (ok / fail / error /
  empty-payload / timeout / no-Worker / construction-throws) via a stubbed
  `Worker`.
- `unsupported.test.ts` — the blocking page per reason + fallback.
- `tests/e2e/unsupported.spec.ts` — real-browser failure UI. The
  worker body (real OPFS I/O) is e2e-covered and excluded from jsdom
  coverage.

## Test plan

- [x] `npm run check` — clean (svelte-check + tsc).
- [x] `npm run test` — 72 vitest pass.
- [x] `npm run test:e2e` — runs against the **real API** (no skip flag):
      `api-smoke` passes (the app boots for a supported browser) and the
      `unsupported` specs pass; lifecycle specs stay skipped (#81).
- [x] `just check` — Python suite, lint, format, typecheck, coverage +
      ruff ratchets, db-check all green.
- [x] CI green — all jobs including the `e2e` job (#197 harness).

## Note

Route is `src/routes/unsupported/+page.svelte` (no leading underscore):
SvelteKit treats `_`-prefixed entries under `src/routes/` as private and
omits them from the route tree, so `_unsupported` would be unreachable.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>