### PR TITLE
test(e2e): bootstrap a migrated API for Playwright + wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,20 +154,12 @@ jobs:
           cache: npm
           cache-dependency-path: src/js/web/package-lock.json
 
-      # The Playwright webServer chain boots the Python API (migrate +
-      # seed the file SQLite DB, then `litestar run`), so the e2e job
-      # needs the uv venv as well as the Node toolchain.
+      # e2e boots the real Python API, so the job needs the uv venv too.
       - run: mkdir -p build/wheel_data
       - run: uv sync
       - run: cd src/js/web && npm ci
 
-      # Browser binary + its OS deps. Chromium only — the config defines
-      # a single `chromium` project.
       - run: cd src/js/web && npx playwright install --with-deps chromium
-
-      # `just test-e2e` runs `playwright test`, which brings up the
-      # migrated-API + Vite pair (no E2E_SKIP_API: e2e always runs with
-      # the API present) and executes the smoke spec.
       - run: just test-e2e
 
       - name: Upload Playwright report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,45 @@ jobs:
           path: src/js/web/coverage/
           retention-days: 14
 
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: src/js/web/package-lock.json
+
+      # The Playwright webServer chain boots the Python API (migrate +
+      # seed the file SQLite DB, then `litestar run`), so the e2e job
+      # needs the uv venv as well as the Node toolchain.
+      - run: mkdir -p build/wheel_data
+      - run: uv sync
+      - run: cd src/js/web && npm ci
+
+      # Browser binary + its OS deps. Chromium only — the config defines
+      # a single `chromium` project.
+      - run: cd src/js/web && npx playwright install --with-deps chromium
+
+      # `just test-e2e` runs `playwright test`, which brings up the
+      # migrated-API + Vite pair (no E2E_SKIP_API: e2e always runs with
+      # the API present) and executes the smoke spec.
+      - run: just test-e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: src/js/web/playwright-report/
+          retention-days: 14
+
   ratchet:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/justfile
+++ b/justfile
@@ -112,12 +112,9 @@ test-js: test-js-unit
 test-js-unit:
 	cd src/js/web && npm run test
 
-# Playwright browser e2e tests (issue #197). Deliberately NOT wired into
-# the `test`/`check` composites: it boots the Python API against a
-# throwaway file SQLite DB (migrate via db-init + seed via
-# bootstrap-admin, per the webServer chain in playwright.config.ts),
-# launches Vite, and drives a real Chromium — too heavy for the fast
-# inner loop. Run it explicitly, and in its own CI job (`.github/workflows/ci.yml`).
+# Browser e2e (Playwright). Kept out of `test`/`check`: it boots the API
+# against a throwaway DB and drives a real browser — too heavy for the
+# inner loop. Runs in its own CI job.
 test-e2e:
 	cd src/js/web && npm run test:e2e
 

--- a/justfile
+++ b/justfile
@@ -103,15 +103,22 @@ typecheck-js:
 test-py:
 	uv run pytest
 
-# Test javascript (Vitest component tests + Playwright browser e2e)
-test-js: test-js-unit test-js-e2e
+# Test javascript (Vitest component tests). Browser e2e is `test-e2e`,
+# kept out of the fast `just test` / `just check` loop because it boots
+# the API (migrate + seed) and a real Chromium — see `test-e2e`.
+test-js: test-js-unit
 
 # Vitest component tests in jsdom
 test-js-unit:
 	cd src/js/web && npm run test
 
-# Playwright browser e2e tests
-test-js-e2e:
+# Playwright browser e2e tests (issue #197). Deliberately NOT wired into
+# the `test`/`check` composites: it boots the Python API against a
+# throwaway file SQLite DB (migrate via db-init + seed via
+# bootstrap-admin, per the webServer chain in playwright.config.ts),
+# launches Vite, and drives a real Chromium — too heavy for the fast
+# inner loop. Run it explicitly, and in its own CI job (`.github/workflows/ci.yml`).
+test-e2e:
 	cd src/js/web && npm run test:e2e
 
 # Run both test suites under coverage and write artifacts

--- a/src/js/web/playwright.config.ts
+++ b/src/js/web/playwright.config.ts
@@ -31,10 +31,14 @@ import { defineConfig } from '@playwright/test'
 const API_PORT = 8765
 const APP_PORT = 5174
 const API_URL = `http://127.0.0.1:${API_PORT}`
-// Vite serves HTTPS via ``@vitejs/plugin-basic-ssl`` so the browser sees
-// a secure context and ``crypto.randomUUID`` / ``crypto.subtle`` are
-// defined. The cert is self-signed, hence ``ignoreHTTPSErrors`` below.
-const APP_URL = `https://127.0.0.1:${APP_PORT}`
+// The e2e app server runs over plain HTTP bound to ``127.0.0.1``.
+// ``127.0.0.1`` is a "potentially trustworthy" origin, so it's a secure
+// context even without TLS — ``crypto.randomUUID`` / ``crypto.subtle``
+// and ``crossOriginIsolated`` (with the COOP/COEP headers Vite sets in
+// ``vite.config.ts``) all work. Plain HTTP avoids the self-signed-cert
+// readiness probe and the IPv4/IPv6 ``localhost`` resolution mismatch
+// that makes ``basic-ssl`` flaky on CI runners.
+const APP_URL = `http://127.0.0.1:${APP_PORT}`
 
 // Throwaway file DB under the OS temp dir — never inside the repo tree,
 // so there's nothing to gitignore and a stale file from a crashed prior
@@ -55,7 +59,6 @@ export default defineConfig({
   use: {
     baseURL: APP_URL,
     trace: 'retain-on-failure',
-    ignoreHTTPSErrors: true,
   },
   webServer: [
     {
@@ -73,10 +76,10 @@ export default defineConfig({
       cwd: '../../..',
       env: {
         NOVAMOC_DB_URL: E2E_DB_URL,
-        // Cookie set over plain-HTTP loopback to the API; the SPA talks
-        // to it through the Vite dev proxy, so the browser only ever
-        // sees the HTTPS origin. Relax Secure so the cookie survives the
-        // proxied login (mirrors the dev opt-out documented in
+        // The SPA reaches the API through the Vite dev proxy, so the
+        // browser only sees the app origin (plain-HTTP loopback). Relax
+        // Secure so the session cookie is actually sent over HTTP
+        // (mirrors the dev opt-out documented in
         // ``AuthSettings.session_cookie_secure``).
         NOVAMOC_AUTH_SESSION_COOKIE_SECURE: 'false',
       },
@@ -89,12 +92,18 @@ export default defineConfig({
       stderr: 'pipe',
     },
     {
-      command: `npm run dev -- --port ${APP_PORT} --strictPort`,
+      // Bind Vite to ``127.0.0.1`` (not the default ``localhost``) so the
+      // readiness probe's IPv4 URL always matches the listening socket —
+      // on CI runners ``localhost`` can resolve to IPv6 ``::1`` first,
+      // leaving the IPv4 probe hanging until the timeout. ``NOVAMOC_NO_HTTPS``
+      // opts out of ``@vitejs/plugin-basic-ssl`` so the server is plain
+      // HTTP (see ``APP_URL`` above for why that's still a secure context).
+      command: `npm run dev -- --port ${APP_PORT} --strictPort --host 127.0.0.1`,
       env: {
         NOVAMOC_API_URL: API_URL,
+        NOVAMOC_NO_HTTPS: '1',
       },
       url: APP_URL,
-      ignoreHTTPSErrors: true,
       reuseExistingServer: false,
       timeout: 30_000,
       stdout: 'pipe',

--- a/src/js/web/playwright.config.ts
+++ b/src/js/web/playwright.config.ts
@@ -5,14 +5,26 @@
  * run is isolated from any local dev servers and from the shared
  * ``novamoc.sqlite`` dev DB:
  *
- * - API at ``E2E_API_PORT`` (8765) with an in-memory aiosqlite +
- *   ``static_pool=true`` so all requests share the same engine.
+ * - API at ``E2E_API_PORT`` (8765) backed by a throwaway *file* SQLite
+ *   DB under the OS temp dir. The app's ADR-021 startup gate
+ *   (``db/_startup.py``) refuses to serve a DB that isn't at Alembic
+ *   HEAD, and an in-memory DB lives and dies with its owning process —
+ *   so a separate ``alchemy upgrade head`` step would migrate a
+ *   throwaway DB that vanishes before ``litestar run`` connects. The
+ *   fix: point ``NOVAMOC_DB_URL`` at a file, run the migrate + seed
+ *   chain (``just bootstrap-dev`` = ``db-init`` + ``bootstrap-admin``)
+ *   against that file, then launch ``litestar run`` against the *same*
+ *   file. The gate then passes and a ``Development`` tenant with an
+ *   ``admin``/``admin`` user is seeded for happy-path login e2e.
  * - Vite at ``E2E_APP_PORT`` (5174) with ``NOVAMOC_API_URL`` pointing
  *   the dev proxy at the test API.
  *
  * ``cwd: '../../..'`` on the API webServer is the repo root from
  * ``src/js/web/``, where ``uv run`` finds ``pyproject.toml``.
  */
+
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { defineConfig } from '@playwright/test'
 
@@ -23,6 +35,15 @@ const API_URL = `http://127.0.0.1:${API_PORT}`
 // a secure context and ``crypto.randomUUID`` / ``crypto.subtle`` are
 // defined. The cert is self-signed, hence ``ignoreHTTPSErrors`` below.
 const APP_URL = `https://127.0.0.1:${APP_PORT}`
+
+// Throwaway file DB under the OS temp dir — never inside the repo tree,
+// so there's nothing to gitignore and a stale file from a crashed prior
+// run is removed (``rm -f``) at the start of the boot chain. The same
+// path threads through migrate, seed, and serve so all three reach one
+// DB. ``aiosqlite`` wants four slashes for an absolute path
+// (``sqlite+aiosqlite:////abs/path``).
+const E2E_DB_PATH = join(tmpdir(), 'novamoc-e2e.sqlite')
+const E2E_DB_URL = `sqlite+aiosqlite:///${E2E_DB_PATH}`
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -38,15 +59,32 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `uv run litestar --app novamoc.asgi:create_app run --host 127.0.0.1 --port ${API_PORT}`,
+      // (1) drop any stale DB file, (2) migrate + seed the file DB via
+      // ``just bootstrap-dev`` (db-init = ``alchemy upgrade head`` then
+      // ``bootstrap-admin`` for the Development tenant + admin/admin),
+      // (3) serve ``litestar run`` against the same file so the ADR-021
+      // startup gate sees a DB at HEAD. ``NOVAMOC_DB_URL`` in ``env``
+      // (below) threads through all three. ``rm -f`` is portable across
+      // the POSIX shells Playwright spawns ``command`` through.
+      command:
+        `rm -f '${E2E_DB_PATH}' '${E2E_DB_PATH}-wal' '${E2E_DB_PATH}-shm' && ` +
+        `just bootstrap-dev && ` +
+        `uv run litestar --app novamoc.asgi:create_app run --host 127.0.0.1 --port ${API_PORT}`,
       cwd: '../../..',
       env: {
-        NOVAMOC_DB_URL: 'sqlite+aiosqlite:///:memory:',
-        NOVAMOC_DB_STATIC_POOL: 'true',
+        NOVAMOC_DB_URL: E2E_DB_URL,
+        // Cookie set over plain-HTTP loopback to the API; the SPA talks
+        // to it through the Vite dev proxy, so the browser only ever
+        // sees the HTTPS origin. Relax Secure so the cookie survives the
+        // proxied login (mirrors the dev opt-out documented in
+        // ``AuthSettings.session_cookie_secure``).
+        NOVAMOC_AUTH_SESSION_COOKIE_SECURE: 'false',
       },
       url: `${API_URL}/openapi`,
       reuseExistingServer: false,
-      timeout: 60_000,
+      // Generous: the chain runs Alembic migrations and an argon2id
+      // password hash (64 MiB, t=3) for the seeded admin before serving.
+      timeout: 120_000,
       stdout: 'pipe',
       stderr: 'pipe',
     },

--- a/src/js/web/playwright.config.ts
+++ b/src/js/web/playwright.config.ts
@@ -1,26 +1,11 @@
 /**
- * Playwright config for novaMOC SPA browser e2e tests.
+ * Playwright config for the novaMOC SPA browser e2e tests.
  *
- * Boots a dedicated API + Vite pair on non-default ports so the test
- * run is isolated from any local dev servers and from the shared
- * ``novamoc.sqlite`` dev DB:
- *
- * - API at ``E2E_API_PORT`` (8765) backed by a throwaway *file* SQLite
- *   DB under the OS temp dir. The app's ADR-021 startup gate
- *   (``db/_startup.py``) refuses to serve a DB that isn't at Alembic
- *   HEAD, and an in-memory DB lives and dies with its owning process —
- *   so a separate ``alchemy upgrade head`` step would migrate a
- *   throwaway DB that vanishes before ``litestar run`` connects. The
- *   fix: point ``NOVAMOC_DB_URL`` at a file, run the migrate + seed
- *   chain (``just bootstrap-dev`` = ``db-init`` + ``bootstrap-admin``)
- *   against that file, then launch ``litestar run`` against the *same*
- *   file. The gate then passes and a ``Development`` tenant with an
- *   ``admin``/``admin`` user is seeded for happy-path login e2e.
- * - Vite at ``E2E_APP_PORT`` (5174) with ``NOVAMOC_API_URL`` pointing
- *   the dev proxy at the test API.
- *
- * ``cwd: '../../..'`` on the API webServer is the repo root from
- * ``src/js/web/``, where ``uv run`` finds ``pyproject.toml``.
+ * Boots an isolated API + Vite pair off the shared dev DB. The API runs
+ * against a throwaway file SQLite DB because the startup gate (ADR-021)
+ * refuses a DB that isn't at Alembic HEAD, and an in-memory DB wouldn't
+ * survive the gap between a separate migrate step and `litestar run` —
+ * so we migrate + seed a file, then serve that same file.
  */
 
 import { tmpdir } from 'node:os'
@@ -31,21 +16,14 @@ import { defineConfig } from '@playwright/test'
 const API_PORT = 8765
 const APP_PORT = 5174
 const API_URL = `http://127.0.0.1:${API_PORT}`
-// The e2e app server runs over plain HTTP bound to ``127.0.0.1``.
-// ``127.0.0.1`` is a "potentially trustworthy" origin, so it's a secure
-// context even without TLS — ``crypto.randomUUID`` / ``crypto.subtle``
-// and ``crossOriginIsolated`` (with the COOP/COEP headers Vite sets in
-// ``vite.config.ts``) all work. Plain HTTP avoids the self-signed-cert
-// readiness probe and the IPv4/IPv6 ``localhost`` resolution mismatch
-// that makes ``basic-ssl`` flaky on CI runners.
+// Plain HTTP on a loopback origin: it's a secure context even without
+// TLS (so crypto + crossOriginIsolated still work), and it dodges the
+// self-signed-cert probe and the IPv4/IPv6 localhost mismatch that make
+// basic-ssl flaky on CI.
 const APP_URL = `http://127.0.0.1:${APP_PORT}`
 
-// Throwaway file DB under the OS temp dir — never inside the repo tree,
-// so there's nothing to gitignore and a stale file from a crashed prior
-// run is removed (``rm -f``) at the start of the boot chain. The same
-// path threads through migrate, seed, and serve so all three reach one
-// DB. ``aiosqlite`` wants four slashes for an absolute path
-// (``sqlite+aiosqlite:////abs/path``).
+// Outside the repo tree so there's nothing to gitignore. aiosqlite
+// needs four slashes for an absolute path (the leading `/` is the third).
 const E2E_DB_PATH = join(tmpdir(), 'novamoc-e2e.sqlite')
 const E2E_DB_URL = `sqlite+aiosqlite:///${E2E_DB_PATH}`
 
@@ -62,13 +40,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      // (1) drop any stale DB file, (2) migrate + seed the file DB via
-      // ``just bootstrap-dev`` (db-init = ``alchemy upgrade head`` then
-      // ``bootstrap-admin`` for the Development tenant + admin/admin),
-      // (3) serve ``litestar run`` against the same file so the ADR-021
-      // startup gate sees a DB at HEAD. ``NOVAMOC_DB_URL`` in ``env``
-      // (below) threads through all three. ``rm -f`` is portable across
-      // the POSIX shells Playwright spawns ``command`` through.
+      // Drop any stale file, migrate + seed, then serve the same DB.
       command:
         `rm -f '${E2E_DB_PATH}' '${E2E_DB_PATH}-wal' '${E2E_DB_PATH}-shm' && ` +
         `just bootstrap-dev && ` +
@@ -76,28 +48,21 @@ export default defineConfig({
       cwd: '../../..',
       env: {
         NOVAMOC_DB_URL: E2E_DB_URL,
-        // The SPA reaches the API through the Vite dev proxy, so the
-        // browser only sees the app origin (plain-HTTP loopback). Relax
-        // Secure so the session cookie is actually sent over HTTP
-        // (mirrors the dev opt-out documented in
-        // ``AuthSettings.session_cookie_secure``).
+        // Relax Secure so the session cookie is sent over the plain-HTTP
+        // loopback (mirrors AuthSettings.session_cookie_secure's opt-out).
         NOVAMOC_AUTH_SESSION_COOKIE_SECURE: 'false',
       },
       url: `${API_URL}/openapi`,
       reuseExistingServer: false,
-      // Generous: the chain runs Alembic migrations and an argon2id
-      // password hash (64 MiB, t=3) for the seeded admin before serving.
+      // Generous: migrations + an argon2 hash run before the API serves.
       timeout: 120_000,
       stdout: 'pipe',
       stderr: 'pipe',
     },
     {
-      // Bind Vite to ``127.0.0.1`` (not the default ``localhost``) so the
-      // readiness probe's IPv4 URL always matches the listening socket —
-      // on CI runners ``localhost`` can resolve to IPv6 ``::1`` first,
-      // leaving the IPv4 probe hanging until the timeout. ``NOVAMOC_NO_HTTPS``
-      // opts out of ``@vitejs/plugin-basic-ssl`` so the server is plain
-      // HTTP (see ``APP_URL`` above for why that's still a secure context).
+      // Bind to 127.0.0.1, not localhost, so the IPv4 readiness probe
+      // matches the socket — on CI, localhost may resolve to ::1 first
+      // and hang the probe. NOVAMOC_NO_HTTPS drops TLS (see APP_URL).
       command: `npm run dev -- --port ${APP_PORT} --strictPort --host 127.0.0.1`,
       env: {
         NOVAMOC_API_URL: API_URL,

--- a/src/js/web/tests/e2e/api-smoke.spec.ts
+++ b/src/js/web/tests/e2e/api-smoke.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * Minimal harness smoke test (issue #197).
+ *
+ * Proves the Playwright e2e pair boots end-to-end *with the real API
+ * present*: the API webServer migrates + seeds a throwaway file SQLite
+ * DB and clears the ADR-021 startup gate, Vite serves the SPA, and the
+ * browser reaches a rendered route. Before #197 this could not pass —
+ * the API crashed at boot against an unmigrated in-memory DB.
+ *
+ * Deliberately small: it exercises the API+app pair, not login logic.
+ * It is NOT skipped (unlike the three lifecycle specs, which wait on
+ * the #81 selector rewrite). It does not depend on the seeded
+ * admin/admin credentials — it only asserts the login route renders.
+ */
+
+import { expect, test } from '@playwright/test'
+
+test('login route renders with the API present', async ({ page }) => {
+  await page.goto('/login')
+
+  await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible()
+  await expect(page.getByRole('textbox', { name: 'Username' })).toBeVisible()
+  await expect(page.getByLabel('Password')).toBeVisible()
+  await expect(page.getByRole('button', { name: /Sign in/ })).toBeVisible()
+})

--- a/src/js/web/tests/e2e/api-smoke.spec.ts
+++ b/src/js/web/tests/e2e/api-smoke.spec.ts
@@ -1,16 +1,8 @@
 /**
- * Minimal harness smoke test (issue #197).
- *
- * Proves the Playwright e2e pair boots end-to-end *with the real API
- * present*: the API webServer migrates + seeds a throwaway file SQLite
- * DB and clears the ADR-021 startup gate, Vite serves the SPA, and the
- * browser reaches a rendered route. Before #197 this could not pass —
- * the API crashed at boot against an unmigrated in-memory DB.
- *
- * Deliberately small: it exercises the API+app pair, not login logic.
- * It is NOT skipped (unlike the three lifecycle specs, which wait on
- * the #81 selector rewrite). It does not depend on the seeded
- * admin/admin credentials — it only asserts the login route renders.
+ * Harness smoke test: proves the e2e pair boots end-to-end with the real
+ * API present — the API clears the ADR-021 startup gate, Vite serves the
+ * SPA, and the browser reaches a rendered route. Asserts only that the
+ * login route renders, not login logic.
  */
 
 import { expect, test } from '@playwright/test'


### PR DESCRIPTION
## Summary

The Playwright e2e API webServer ran `litestar run` against an in-memory
SQLite DB that nothing migrated, so the ADR-021 startup gate refused to
serve and the process crashed — the e2e API never ran, and CI never ran
the suite at all.

**API bootstrap.** An in-memory DB dies with its owning process, so a
separate migrate step can't reach the server's DB. Point `NOVAMOC_DB_URL`
at a throwaway file under the OS temp dir and make the webServer command
migrate + seed (`just bootstrap-dev` = `db-init` + `bootstrap-admin`,
seeding a `Development` tenant and `admin`/`admin`) then serve the same
file, so the gate passes. `NOVAMOC_DB_STATIC_POOL` is dropped (a no-op
for a file-backed DB).

**App server over HTTP / 127.0.0.1.** The readiness probe targeted
`127.0.0.1` while Vite bound to `localhost`, which resolves to IPv6 `::1`
first on CI runners — the IPv4 probe hung until timeout. Bind Vite to
`127.0.0.1` and drop TLS (`NOVAMOC_NO_HTTPS=1`); a loopback origin is a
secure context without a cert, so `crypto` and `crossOriginIsolated`
still work and the self-signed-cert probe flakiness goes away.
`NOVAMOC_AUTH_SESSION_COOKIE_SECURE=false` lets the session cookie ride
the plain-HTTP loopback.

**Also:**
- New non-skipped smoke spec (`tests/e2e/api-smoke.spec.ts`) asserts the
  login route renders with the real API present. The three lifecycle
  specs stay skipped (that's #81).
- New `just test-e2e` recipe, kept out of `just test` / `just check`
  because it boots the API plus a real browser.
- New `e2e` CI job (uv + Node + `playwright install --with-deps chromium`).

e2e always runs with the API present — there is no skip-the-API mode.

## Test plan

- [x] `npm run test:e2e` — API boots migrated + seeded, smoke passes (`1 passed, 3 skipped`).
- [x] red→green: the in-memory config crashes with `AlembicRevisionMismatchError`; the file-DB chain serves `/openapi`.
- [x] `just check` green.
- [x] CI `e2e` job green.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>