### PR TITLE
feat(client): typed repository layer over the local DB (closes #148)

### DIFF
--- a/.coverage-ratchet.json
+++ b/.coverage-ratchet.json
@@ -1,7 +1,7 @@
 {
   "js": {
-    "branch": 56.0,
-    "line": 73.0
+    "branch": 58.0,
+    "line": 75.0
   },
   "python": {
     "branch": 87.0,

--- a/src/js/web/src/lib/db/repo/_rows.ts
+++ b/src/js/web/src/lib/db/repo/_rows.ts
@@ -1,0 +1,133 @@
+/**
+ * Row shapes the repository layer reads and writes.
+ *
+ * These mirror the client DDL (`ddl.ts`) projection and log tables, modulo the
+ * conventions the repo enforces:
+ *
+ *   - `tenant_id` never appears. The pinned tenant (see `_tenant.ts`) supplies
+ *     it; exposing it on the row type would invite a call site to set it, which
+ *     is exactly the cross-tenant footgun the brand exists to prevent.
+ *   - SQLite affinities are surfaced as their JS-native types: INTEGER booleans
+ *     (`deleted`, `active`) become `boolean`, and `properties` / `value_json`
+ *     TEXT columns become parsed JSON. The mapper in each repo owns the
+ *     (de)serialisation, per the spike (single chokepoint per table).
+ *   - Entity rows carry no `name` column (ADR-015): the name is reconstructed
+ *     from the `col:name` field value, not stored on the projection row.
+ *
+ * Defined here rather than in the shared `db/types.ts` so the repo build-out
+ * does not collide with the parallel fold/ingest work on that file.
+ */
+
+/** A parsed JSON object, as held in `properties` / `value_json` columns. */
+export type Json = unknown
+
+// --- Data projections -------------------------------------------------------
+
+/** An `assets` projection row (sans `tenant_id`). */
+export interface AssetRow {
+  id: string
+  type_id: string
+  properties: Record<string, Json>
+  deleted: boolean
+  row_state_hlc: string
+  created_at: string | null
+  updated_at: string | null
+}
+
+/** What an `assets` upsert writes; audit timestamps are server/fold-owned. */
+export interface AssetDraft {
+  id: string
+  type_id: string
+  properties: Record<string, Json>
+  deleted: boolean
+  row_state_hlc: string
+}
+
+/** A `maintenance_records` projection row (sans `tenant_id`). */
+export interface MaintenanceRecordRow {
+  id: string
+  type_id: string
+  asset_id: string
+  properties: Record<string, Json>
+  deleted: boolean
+  row_state_hlc: string
+  created_at: string | null
+  updated_at: string | null
+}
+
+/** What a `maintenance_records` upsert writes. */
+export interface MaintenanceRecordDraft {
+  id: string
+  type_id: string
+  asset_id: string
+  properties: Record<string, Json>
+  deleted: boolean
+  row_state_hlc: string
+}
+
+/** An `asset_field_values` EAV/LWW row (sans `tenant_id`). */
+export interface AssetFieldValueRow {
+  asset_id: string
+  field_id: string
+  value_json: Json
+  hlc: string
+}
+
+/** A `maintenance_record_field_values` EAV/LWW row (sans `tenant_id`). */
+export interface MaintenanceRecordFieldValueRow {
+  maintenance_record_id: string
+  field_id: string
+  value_json: Json
+  hlc: string
+}
+
+// --- Schema projections (read-only) -----------------------------------------
+
+/** An `asset_types` / `maintenance_record_types` row. */
+export interface TypeRow {
+  id: string
+  name: string
+  active: boolean
+}
+
+/** An `asset_type_fields` / `maintenance_record_type_fields` row. */
+export interface TypeFieldRow {
+  id: string
+  parent_id: string
+  name: string
+  data_type: string
+  validation: Json | null
+  active: boolean
+}
+
+// --- Event log (read-only) --------------------------------------------------
+
+/** An `event_log` row — the local copy of the catch-up stream (ADR-011). */
+export interface EventLogRow {
+  seq: number
+  hlc: string
+  schema_version: number
+  table_name: string
+  type_id: string
+  entity_id: string
+  field_id: string | null
+  op: string
+  value_json: Json | null
+  received_at: string | null
+}
+
+// --- Pending queue (read + status writes) -----------------------------------
+
+/** A `local_pending_events` row — a write generated offline (ADR-013). */
+export interface PendingEventRow {
+  client_seq: number
+  hlc: string
+  schema_version: number
+  table_name: string
+  type_id: string
+  entity_id: string
+  field_id: string | null
+  op: string
+  value_json: Json | null
+  created_at: string | null
+}

--- a/src/js/web/src/lib/db/repo/_sql.ts
+++ b/src/js/web/src/lib/db/repo/_sql.ts
@@ -1,0 +1,39 @@
+/**
+ * Column (de)serialisation helpers shared by the repository mappers.
+ *
+ * SQLite has no boolean or JSON affinity: booleans land as INTEGER 0/1 and JSON
+ * columns as TEXT. Each repo's row mapper is the single chokepoint (per the
+ * spike) that converts between the on-disk representation and the JS-native row
+ * type, so the conversions live here rather than being re-derived per table.
+ */
+
+import type { Json } from './_rows'
+
+/** INTEGER 0/1 (or any SQLite truthy/falsy value) to `boolean`. */
+export function toBool(value: unknown): boolean {
+  return Boolean(value)
+}
+
+/** `boolean` to INTEGER 0/1 for a bind list. */
+export function fromBool(value: boolean): number {
+  return value ? 1 : 0
+}
+
+/**
+ * A TEXT JSON column to its parsed value. A `null` column (NULL value, e.g. a
+ * cleared field) parses to `null`; a missing string is treated as `null` too.
+ */
+export function parseJson(value: unknown): Json {
+  if (value === null || value === undefined) {
+    return null
+  }
+  return JSON.parse(value as string)
+}
+
+/** A JS value to a TEXT JSON column for a bind list. `null` stays SQL NULL. */
+export function stringifyJson(value: Json): string | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+  return JSON.stringify(value)
+}

--- a/src/js/web/src/lib/db/repo/_tenant.ts
+++ b/src/js/web/src/lib/db/repo/_tenant.ts
@@ -1,0 +1,64 @@
+/**
+ * Tenant pinning and compile-time tenant safety for the repository layer
+ * (ADR-014).
+ *
+ * Every repository method is reached through {@link withTenant}, which binds a
+ * tenant id once and threads it into every WHERE clause and VALUES list. The
+ * tenant id is never an argument on the individual methods, so a call site
+ * cannot forget it or pass the wrong one.
+ *
+ * Runtime scoping is half the story; the other half is making a cross-tenant
+ * mistake a *compile* error. A repo set is branded with a phantom type `B` the
+ * caller chooses (distinct brands for distinct tenants). Two things follow:
+ *
+ *   - Every row read out is tagged {@link TenantScoped}`<T, B>` — it carries a
+ *     phantom `[BRAND]: B` property.
+ *   - An `upsert` accepts {@link Writable}`<T, B>`: a plain (unbranded) draft
+ *     *or* a row already branded `B`. A row branded `'a'` has `[BRAND]: 'a'`,
+ *     which is not assignable to the `[BRAND]?: 'b'` an `upsert` on the `'b'`
+ *     repo wants — so handing tenant A's row to tenant B's `upsert` is a type
+ *     error, while a freshly-built draft (no brand) still type-checks for
+ *     either tenant.
+ *
+ * The brand is `declare`d, so it never exists at runtime — no bytes on the row,
+ * no work for the fold.
+ */
+
+import type { DbHandle } from '../bootstrap'
+
+declare const BRAND: unique symbol
+
+/**
+ * A value tagged with the phantom tenant brand `B`. `[BRAND]` is `declare`d, so
+ * it never exists at runtime; it only makes two differently branded values
+ * structurally incompatible to the type checker.
+ */
+export type TenantScoped<T, B> = T & { readonly [BRAND]: B }
+
+/**
+ * What an `upsert` accepts: a plain draft `T` (the brand property absent — a
+ * freshly-built row), or a `T` already branded `B` (a row read from this same
+ * repo). A `T` branded with a *different* tenant has `[BRAND]` set to the wrong
+ * literal and is rejected.
+ */
+export type Writable<T, B> = T & { readonly [BRAND]?: B }
+
+/**
+ * The connection plus the pinned tenant id, handed to every repository
+ * factory. The brand only narrows the *type* of `tenantId`; at runtime it is
+ * the same string the caller passed.
+ */
+export interface TenantContext<B> {
+  readonly db: DbHandle
+  readonly tenantId: string
+}
+
+/**
+ * Brand an opaque tenant id so the type system can tell two tenants apart. The
+ * default brand `unknown` keeps a single-tenant call site ergonomic (no type
+ * argument needed); cross-tenant code that must not mix rows passes a distinct
+ * literal/symbol brand per tenant.
+ */
+export function tenant<B = unknown>(tenantId: string): TenantScoped<string, B> {
+  return tenantId as TenantScoped<string, B>
+}

--- a/src/js/web/src/lib/db/repo/asset.ts
+++ b/src/js/web/src/lib/db/repo/asset.ts
@@ -22,6 +22,7 @@ function rowToAsset<B>(row: unknown[]): TenantScoped<AssetRow, B> {
   return {
     id: row[0] as string,
     type_id: row[1] as string,
+    // Invariant: assets.properties is always a JSON object (ADR-012 fold).
     properties: parseJson(row[2]) as Record<string, unknown>,
     deleted: toBool(row[3]),
     row_state_hlc: row[4] as string,

--- a/src/js/web/src/lib/db/repo/asset.ts
+++ b/src/js/web/src/lib/db/repo/asset.ts
@@ -1,0 +1,103 @@
+/**
+ * Repository over the `assets` projection (ADR-012 / ADR-019).
+ *
+ * Hand-rolled inline SQL per the E1.4 spike. Every statement carries the
+ * pinned `tenant_id` (from {@link TenantContext}) in its WHERE / VALUES, so a
+ * repo bound to tenant A cannot read or write tenant B's rows. Reads funnel
+ * through {@link rowToAsset} — the typed mapper is where SQL-column drift is
+ * caught (the spike's type-safety chokepoint) and where INTEGER/JSON columns
+ * become their JS-native shapes.
+ */
+
+import type { TenantContext, TenantScoped, Writable } from './_tenant'
+import type { AssetDraft, AssetRow } from './_rows'
+import { fromBool, parseJson, stringifyJson, toBool } from './_sql'
+
+// Explicit column list (not SELECT *) so the positional `rowMode: 'array'`
+// result lines up with the mapper regardless of on-disk column order.
+const COLUMNS =
+  'id, type_id, properties, deleted, row_state_hlc, created_at, updated_at'
+
+function rowToAsset<B>(row: unknown[]): TenantScoped<AssetRow, B> {
+  return {
+    id: row[0] as string,
+    type_id: row[1] as string,
+    properties: parseJson(row[2]) as Record<string, unknown>,
+    deleted: toBool(row[3]),
+    row_state_hlc: row[4] as string,
+    created_at: (row[5] as string | null) ?? null,
+    updated_at: (row[6] as string | null) ?? null,
+  } as TenantScoped<AssetRow, B>
+}
+
+export interface AssetRepo<B> {
+  listByType(typeId: string): Promise<TenantScoped<AssetRow, B>[]>
+  getById(id: string): Promise<TenantScoped<AssetRow, B> | null>
+  upsert(draft: Writable<AssetDraft, B>): Promise<void>
+  archive(id: string, hlc: string): Promise<void>
+  restore(id: string, hlc: string): Promise<void>
+  delete(id: string): Promise<void>
+}
+
+export function makeAssetRepo<B>(ctx: TenantContext<B>): AssetRepo<B> {
+  const { db, tenantId } = ctx
+
+  return {
+    async listByType(typeId) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM assets WHERE tenant_id = ? AND type_id = ? ORDER BY id`,
+        [tenantId, typeId],
+      )
+      return rows.map((row) => rowToAsset<B>(row))
+    },
+
+    async getById(id) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM assets WHERE tenant_id = ? AND id = ?`,
+        [tenantId, id],
+      )
+      return rows.length ? rowToAsset<B>(rows[0]) : null
+    },
+
+    async upsert(draft) {
+      await db.exec(
+        `INSERT INTO assets (tenant_id, id, type_id, properties, deleted, row_state_hlc)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT (tenant_id, id) DO UPDATE SET
+           type_id = excluded.type_id,
+           properties = excluded.properties,
+           deleted = excluded.deleted,
+           row_state_hlc = excluded.row_state_hlc`,
+        [
+          tenantId,
+          draft.id,
+          draft.type_id,
+          stringifyJson(draft.properties),
+          fromBool(draft.deleted),
+          draft.row_state_hlc,
+        ],
+      )
+    },
+
+    async archive(id, hlc) {
+      await db.exec(
+        'UPDATE assets SET deleted = 1, row_state_hlc = ? WHERE tenant_id = ? AND id = ?',
+        [hlc, tenantId, id],
+      )
+    },
+
+    async restore(id, hlc) {
+      await db.exec(
+        'UPDATE assets SET deleted = 0, row_state_hlc = ? WHERE tenant_id = ? AND id = ?',
+        [hlc, tenantId, id],
+      )
+    },
+
+    async delete(id) {
+      await db.exec('DELETE FROM assets WHERE tenant_id = ? AND id = ?', [
+        tenantId,
+        id,
+      ])
+    },
+  }
+}

--- a/src/js/web/src/lib/db/repo/asset_field_value.ts
+++ b/src/js/web/src/lib/db/repo/asset_field_value.ts
@@ -1,0 +1,83 @@
+/**
+ * Repository over the `asset_field_values` EAV/LWW table (ADR-007 / ADR-011).
+ *
+ * Field values are keyed `(tenant_id, asset_id, field_id)` and ordered by
+ * `hlc`. `clear` writes a JSON `null` value (a tombstoned-but-present field,
+ * ADR-019) rather than deleting the row — the row stays so its `hlc` keeps
+ * guarding later writes.
+ */
+
+import type { TenantContext, TenantScoped, Writable } from './_tenant'
+import type { AssetFieldValueRow, Json } from './_rows'
+import { parseJson, stringifyJson } from './_sql'
+
+const COLUMNS = 'asset_id, field_id, value_json, hlc'
+
+function rowToFieldValue<B>(
+  row: unknown[],
+): TenantScoped<AssetFieldValueRow, B> {
+  return {
+    asset_id: row[0] as string,
+    field_id: row[1] as string,
+    value_json: parseJson(row[2]),
+    hlc: row[3] as string,
+  } as TenantScoped<AssetFieldValueRow, B>
+}
+
+export interface AssetFieldValueUpsert {
+  asset_id: string
+  field_id: string
+  value_json: Json
+  hlc: string
+}
+
+export interface AssetFieldValueRepo<B> {
+  listByAsset(assetId: string): Promise<TenantScoped<AssetFieldValueRow, B>[]>
+  upsert(value: Writable<AssetFieldValueUpsert, B>): Promise<void>
+  clear(assetId: string, fieldId: string, hlc: string): Promise<void>
+}
+
+export function makeAssetFieldValueRepo<B>(
+  ctx: TenantContext<B>,
+): AssetFieldValueRepo<B> {
+  const { db, tenantId } = ctx
+
+  return {
+    async listByAsset(assetId) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM asset_field_values
+         WHERE tenant_id = ? AND asset_id = ? ORDER BY field_id`,
+        [tenantId, assetId],
+      )
+      return rows.map((row) => rowToFieldValue<B>(row))
+    },
+
+    async upsert(value) {
+      await db.exec(
+        `INSERT INTO asset_field_values (tenant_id, asset_id, field_id, value_json, hlc)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT (tenant_id, asset_id, field_id) DO UPDATE SET
+           value_json = excluded.value_json,
+           hlc = excluded.hlc`,
+        [
+          tenantId,
+          value.asset_id,
+          value.field_id,
+          stringifyJson(value.value_json),
+          value.hlc,
+        ],
+      )
+    },
+
+    async clear(assetId, fieldId, hlc) {
+      await db.exec(
+        `INSERT INTO asset_field_values (tenant_id, asset_id, field_id, value_json, hlc)
+         VALUES (?, ?, ?, NULL, ?)
+         ON CONFLICT (tenant_id, asset_id, field_id) DO UPDATE SET
+           value_json = NULL,
+           hlc = excluded.hlc`,
+        [tenantId, assetId, fieldId, hlc],
+      )
+    },
+  }
+}

--- a/src/js/web/src/lib/db/repo/event_log.ts
+++ b/src/js/web/src/lib/db/repo/event_log.ts
@@ -1,0 +1,65 @@
+/**
+ * Read-only repository over the local `event_log` (ADR-011 / ADR-013).
+ *
+ * The event log is written by the catch-up/ingest path, not by this layer.
+ * E1.9 ships only the read access the debug surface and the fold-parity tests
+ * need: a cursor-ordered scan and a single-row lookup by `seq`. Cross-tenant
+ * gaps in `seq` are expected (it is the server's globally-monotonic cursor), so
+ * every read still pins `tenant_id`.
+ */
+
+import type { TenantContext, TenantScoped } from './_tenant'
+import type { EventLogRow } from './_rows'
+import { parseJson } from './_sql'
+
+const COLUMNS =
+  'seq, hlc, schema_version, table_name, type_id, entity_id, field_id, op, value_json, received_at'
+
+function rowToEvent<B>(row: unknown[]): TenantScoped<EventLogRow, B> {
+  return {
+    seq: row[0] as number,
+    hlc: row[1] as string,
+    schema_version: row[2] as number,
+    table_name: row[3] as string,
+    type_id: row[4] as string,
+    entity_id: row[5] as string,
+    field_id: (row[6] as string | null) ?? null,
+    op: row[7] as string,
+    value_json: parseJson(row[8]),
+    received_at: (row[9] as string | null) ?? null,
+  } as TenantScoped<EventLogRow, B>
+}
+
+export interface EventLogRepo<B> {
+  /** Events with `seq > after`, in ascending `seq` order, capped at `limit`. */
+  listSince(
+    after: number,
+    limit?: number,
+  ): Promise<TenantScoped<EventLogRow, B>[]>
+  getBySeq(seq: number): Promise<TenantScoped<EventLogRow, B> | null>
+}
+
+const DEFAULT_LIMIT = 500
+
+export function makeEventLogRepo<B>(ctx: TenantContext<B>): EventLogRepo<B> {
+  const { db, tenantId } = ctx
+
+  return {
+    async listSince(after, limit = DEFAULT_LIMIT) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM event_log
+         WHERE tenant_id = ? AND seq > ? ORDER BY seq LIMIT ?`,
+        [tenantId, after, limit],
+      )
+      return rows.map((row) => rowToEvent<B>(row))
+    },
+
+    async getBySeq(seq) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM event_log WHERE tenant_id = ? AND seq = ?`,
+        [tenantId, seq],
+      )
+      return rows.length ? rowToEvent<B>(rows[0]) : null
+    },
+  }
+}

--- a/src/js/web/src/lib/db/repo/index.ts
+++ b/src/js/web/src/lib/db/repo/index.ts
@@ -1,0 +1,94 @@
+/**
+ * Typed repository façade over the local SQLite-WASM DB (ADR-003).
+ *
+ * E3/E4 read and write local data exclusively through this layer — never raw
+ * SQL. The implementation is hand-rolled inline SQL with typed mappers, the
+ * approach chosen by the E1.4 spike (query builders cost too much bundle weight
+ * for a local-first client).
+ *
+ * {@link withTenant} is the single entry point: it binds a tenant id once and
+ * returns the full set of repos, every one of which pins that tenant into every
+ * statement. The repo set (and the rows it yields) is branded with a phantom
+ * tenant type `B`, so a row read under one brand cannot be passed to another
+ * brand's `upsert` — a cross-tenant write is a compile error, not just a
+ * runtime guard. See `_tenant.ts` for the brand machinery.
+ */
+
+import type { DbHandle } from '../bootstrap'
+import type { TenantContext } from './_tenant'
+import { makeAssetRepo } from './asset'
+import type { AssetRepo } from './asset'
+import { makeAssetFieldValueRepo } from './asset_field_value'
+import type { AssetFieldValueRepo } from './asset_field_value'
+import { makeMaintenanceRecordRepo } from './maintenance_record'
+import type { MaintenanceRecordRepo } from './maintenance_record'
+import { makeMaintenanceRecordFieldValueRepo } from './maintenance_record_field_value'
+import type { MaintenanceRecordFieldValueRepo } from './maintenance_record_field_value'
+import { makeSchemaProjectionRepo } from './schema_projection'
+import type { SchemaProjectionRepo } from './schema_projection'
+import { makeEventLogRepo } from './event_log'
+import type { EventLogRepo } from './event_log'
+import { makePendingQueueRepo } from './pending_queue'
+import type { PendingQueueRepo } from './pending_queue'
+
+export type { TenantContext, TenantScoped, Writable } from './_tenant'
+export type {
+  AssetDraft,
+  AssetRow,
+  MaintenanceRecordDraft,
+  MaintenanceRecordRow,
+  AssetFieldValueRow,
+  MaintenanceRecordFieldValueRow,
+  TypeRow,
+  TypeFieldRow,
+  EventLogRow,
+  PendingEventRow,
+} from './_rows'
+export type { AssetRepo } from './asset'
+export type {
+  AssetFieldValueRepo,
+  AssetFieldValueUpsert,
+} from './asset_field_value'
+export type { MaintenanceRecordRepo } from './maintenance_record'
+export type {
+  MaintenanceRecordFieldValueRepo,
+  MaintenanceRecordFieldValueUpsert,
+} from './maintenance_record_field_value'
+export type { SchemaProjectionRepo } from './schema_projection'
+export type { EventLogRepo } from './event_log'
+export type { PendingQueueRepo } from './pending_queue'
+
+/** The full set of repositories, all pinned to one branded tenant. */
+export interface RepoSet<B> {
+  assets: AssetRepo<B>
+  assetFieldValues: AssetFieldValueRepo<B>
+  maintenanceRecords: MaintenanceRecordRepo<B>
+  maintenanceRecordFieldValues: MaintenanceRecordFieldValueRepo<B>
+  schema: SchemaProjectionRepo<B>
+  events: EventLogRepo<B>
+  pending: PendingQueueRepo<B>
+}
+
+/**
+ * Bind `db` to `tenantId` and return the full repository set for that tenant.
+ *
+ * The phantom brand `B` defaults to `unknown` so single-tenant call sites need
+ * no type argument. Code that juggles two tenants (and must not mix their rows)
+ * passes a distinct brand per tenant — `withTenant<'a'>(...)` vs
+ * `withTenant<'b'>(...)` — which makes a cross-tenant row a type error.
+ */
+export function withTenant<B = unknown>(
+  db: DbHandle,
+  tenantId: string,
+): RepoSet<B> {
+  const ctx: TenantContext<B> = { db, tenantId }
+  return {
+    assets: makeAssetRepo(ctx),
+    assetFieldValues: makeAssetFieldValueRepo(ctx),
+    maintenanceRecords: makeMaintenanceRecordRepo(ctx),
+    maintenanceRecordFieldValues: makeMaintenanceRecordFieldValueRepo(ctx),
+    schema: makeSchemaProjectionRepo(ctx),
+    events: makeEventLogRepo(ctx),
+    pending: makePendingQueueRepo(ctx),
+  }
+}

--- a/src/js/web/src/lib/db/repo/maintenance_record.ts
+++ b/src/js/web/src/lib/db/repo/maintenance_record.ts
@@ -1,0 +1,103 @@
+/**
+ * Repository over the `maintenance_records` projection (ADR-012 / ADR-019).
+ *
+ * Same shape as {@link makeAssetRepo}, plus the parent `asset_id` a maintenance
+ * record carries. Tenant-pinned and mapper-chokepointed for the same reasons.
+ */
+
+import type { TenantContext, TenantScoped, Writable } from './_tenant'
+import type { MaintenanceRecordDraft, MaintenanceRecordRow } from './_rows'
+import { fromBool, parseJson, stringifyJson, toBool } from './_sql'
+
+const COLUMNS =
+  'id, type_id, asset_id, properties, deleted, row_state_hlc, created_at, updated_at'
+
+function rowToRecord<B>(row: unknown[]): TenantScoped<MaintenanceRecordRow, B> {
+  return {
+    id: row[0] as string,
+    type_id: row[1] as string,
+    asset_id: row[2] as string,
+    properties: parseJson(row[3]) as Record<string, unknown>,
+    deleted: toBool(row[4]),
+    row_state_hlc: row[5] as string,
+    created_at: (row[6] as string | null) ?? null,
+    updated_at: (row[7] as string | null) ?? null,
+  } as TenantScoped<MaintenanceRecordRow, B>
+}
+
+export interface MaintenanceRecordRepo<B> {
+  listByType(typeId: string): Promise<TenantScoped<MaintenanceRecordRow, B>[]>
+  getById(id: string): Promise<TenantScoped<MaintenanceRecordRow, B> | null>
+  upsert(draft: Writable<MaintenanceRecordDraft, B>): Promise<void>
+  archive(id: string, hlc: string): Promise<void>
+  restore(id: string, hlc: string): Promise<void>
+  delete(id: string): Promise<void>
+}
+
+export function makeMaintenanceRecordRepo<B>(
+  ctx: TenantContext<B>,
+): MaintenanceRecordRepo<B> {
+  const { db, tenantId } = ctx
+
+  return {
+    async listByType(typeId) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM maintenance_records WHERE tenant_id = ? AND type_id = ? ORDER BY id`,
+        [tenantId, typeId],
+      )
+      return rows.map((row) => rowToRecord<B>(row))
+    },
+
+    async getById(id) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM maintenance_records WHERE tenant_id = ? AND id = ?`,
+        [tenantId, id],
+      )
+      return rows.length ? rowToRecord<B>(rows[0]) : null
+    },
+
+    async upsert(draft) {
+      await db.exec(
+        `INSERT INTO maintenance_records
+           (tenant_id, id, type_id, asset_id, properties, deleted, row_state_hlc)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (tenant_id, id) DO UPDATE SET
+           type_id = excluded.type_id,
+           asset_id = excluded.asset_id,
+           properties = excluded.properties,
+           deleted = excluded.deleted,
+           row_state_hlc = excluded.row_state_hlc`,
+        [
+          tenantId,
+          draft.id,
+          draft.type_id,
+          draft.asset_id,
+          stringifyJson(draft.properties),
+          fromBool(draft.deleted),
+          draft.row_state_hlc,
+        ],
+      )
+    },
+
+    async archive(id, hlc) {
+      await db.exec(
+        'UPDATE maintenance_records SET deleted = 1, row_state_hlc = ? WHERE tenant_id = ? AND id = ?',
+        [hlc, tenantId, id],
+      )
+    },
+
+    async restore(id, hlc) {
+      await db.exec(
+        'UPDATE maintenance_records SET deleted = 0, row_state_hlc = ? WHERE tenant_id = ? AND id = ?',
+        [hlc, tenantId, id],
+      )
+    },
+
+    async delete(id) {
+      await db.exec(
+        'DELETE FROM maintenance_records WHERE tenant_id = ? AND id = ?',
+        [tenantId, id],
+      )
+    },
+  }
+}

--- a/src/js/web/src/lib/db/repo/maintenance_record.ts
+++ b/src/js/web/src/lib/db/repo/maintenance_record.ts
@@ -17,6 +17,7 @@ function rowToRecord<B>(row: unknown[]): TenantScoped<MaintenanceRecordRow, B> {
     id: row[0] as string,
     type_id: row[1] as string,
     asset_id: row[2] as string,
+    // Invariant: maintenance_records.properties is always a JSON object (ADR-012 fold).
     properties: parseJson(row[3]) as Record<string, unknown>,
     deleted: toBool(row[4]),
     row_state_hlc: row[5] as string,

--- a/src/js/web/src/lib/db/repo/maintenance_record_field_value.ts
+++ b/src/js/web/src/lib/db/repo/maintenance_record_field_value.ts
@@ -1,0 +1,86 @@
+/**
+ * Repository over the `maintenance_record_field_values` EAV/LWW table
+ * (ADR-007 / ADR-011).
+ *
+ * Same shape as {@link makeAssetFieldValueRepo}, keyed on
+ * `(tenant_id, maintenance_record_id, field_id)`.
+ */
+
+import type { TenantContext, TenantScoped, Writable } from './_tenant'
+import type { Json, MaintenanceRecordFieldValueRow } from './_rows'
+import { parseJson, stringifyJson } from './_sql'
+
+const COLUMNS = 'maintenance_record_id, field_id, value_json, hlc'
+
+function rowToFieldValue<B>(
+  row: unknown[],
+): TenantScoped<MaintenanceRecordFieldValueRow, B> {
+  return {
+    maintenance_record_id: row[0] as string,
+    field_id: row[1] as string,
+    value_json: parseJson(row[2]),
+    hlc: row[3] as string,
+  } as TenantScoped<MaintenanceRecordFieldValueRow, B>
+}
+
+export interface MaintenanceRecordFieldValueUpsert {
+  maintenance_record_id: string
+  field_id: string
+  value_json: Json
+  hlc: string
+}
+
+export interface MaintenanceRecordFieldValueRepo<B> {
+  listByRecord(
+    recordId: string,
+  ): Promise<TenantScoped<MaintenanceRecordFieldValueRow, B>[]>
+  upsert(value: Writable<MaintenanceRecordFieldValueUpsert, B>): Promise<void>
+  clear(recordId: string, fieldId: string, hlc: string): Promise<void>
+}
+
+export function makeMaintenanceRecordFieldValueRepo<B>(
+  ctx: TenantContext<B>,
+): MaintenanceRecordFieldValueRepo<B> {
+  const { db, tenantId } = ctx
+
+  return {
+    async listByRecord(recordId) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM maintenance_record_field_values
+         WHERE tenant_id = ? AND maintenance_record_id = ? ORDER BY field_id`,
+        [tenantId, recordId],
+      )
+      return rows.map((row) => rowToFieldValue<B>(row))
+    },
+
+    async upsert(value) {
+      await db.exec(
+        `INSERT INTO maintenance_record_field_values
+           (tenant_id, maintenance_record_id, field_id, value_json, hlc)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT (tenant_id, maintenance_record_id, field_id) DO UPDATE SET
+           value_json = excluded.value_json,
+           hlc = excluded.hlc`,
+        [
+          tenantId,
+          value.maintenance_record_id,
+          value.field_id,
+          stringifyJson(value.value_json),
+          value.hlc,
+        ],
+      )
+    },
+
+    async clear(recordId, fieldId, hlc) {
+      await db.exec(
+        `INSERT INTO maintenance_record_field_values
+           (tenant_id, maintenance_record_id, field_id, value_json, hlc)
+         VALUES (?, ?, ?, NULL, ?)
+         ON CONFLICT (tenant_id, maintenance_record_id, field_id) DO UPDATE SET
+           value_json = NULL,
+           hlc = excluded.hlc`,
+        [tenantId, recordId, fieldId, hlc],
+      )
+    },
+  }
+}

--- a/src/js/web/src/lib/db/repo/pending_queue.ts
+++ b/src/js/web/src/lib/db/repo/pending_queue.ts
@@ -1,0 +1,91 @@
+/**
+ * Repository over `local_pending_events` — the offline write queue (ADR-013).
+ *
+ * E1.10's drainer is the consumer: it lists pending rows in HLC order, POSTs
+ * them, and reports the outcome back here. The write path that *enqueues* rows
+ * is E1.10's; this layer ships the read + status surface the drainer needs.
+ *
+ * The queue's storage contract today is "a row present == still pending." So:
+ *
+ *   - `markSent` deletes the row. A successfully-POSTed event is authoritative
+ *     on the server and arrives back through the catch-up stream, so the local
+ *     pending copy is redundant once accepted (the spec's retention window is
+ *     an E1.10 refinement, not a column this layer owns).
+ *   - `recordFailure` on a *transient* failure leaves the row in place so the
+ *     next drain re-sends it — which is the entire durability guarantee
+ *     (a failed POST must not lose the event). Persisting a *permanent*
+ *     rejection (a status/reason column for the debug surface) requires a DDL
+ *     column that lands with E1.10; until then `recordFailure` records the
+ *     attempt without mutating the row, keeping it eligible for retry.
+ */
+
+import type { TenantContext, TenantScoped } from './_tenant'
+import type { PendingEventRow } from './_rows'
+import { parseJson } from './_sql'
+
+const COLUMNS =
+  'client_seq, hlc, schema_version, table_name, type_id, entity_id, field_id, op, value_json, created_at'
+
+function rowToPending<B>(row: unknown[]): TenantScoped<PendingEventRow, B> {
+  return {
+    client_seq: row[0] as number,
+    hlc: row[1] as string,
+    schema_version: row[2] as number,
+    table_name: row[3] as string,
+    type_id: row[4] as string,
+    entity_id: row[5] as string,
+    field_id: (row[6] as string | null) ?? null,
+    op: row[7] as string,
+    value_json: parseJson(row[8]),
+    created_at: (row[9] as string | null) ?? null,
+  } as TenantScoped<PendingEventRow, B>
+}
+
+export interface PendingQueueRepo<B> {
+  /** Pending rows in HLC order (the send order), capped at `limit`. */
+  listPending(limit?: number): Promise<TenantScoped<PendingEventRow, B>[]>
+  /** A row the server accepted; remove it from the queue. */
+  markSent(clientSeq: number): Promise<void>
+  /**
+   * Report a failed send attempt. Leaves the row queued for retry; the
+   * `reason` is for the caller's logging/debug surface, not persisted yet.
+   */
+  recordFailure(clientSeq: number, reason: string): Promise<void>
+}
+
+const DEFAULT_LIMIT = 500
+
+export function makePendingQueueRepo<B>(
+  ctx: TenantContext<B>,
+): PendingQueueRepo<B> {
+  const { db, tenantId } = ctx
+
+  return {
+    async listPending(limit = DEFAULT_LIMIT) {
+      const rows = await db.exec(
+        `SELECT ${COLUMNS} FROM local_pending_events
+         WHERE tenant_id = ? ORDER BY hlc LIMIT ?`,
+        [tenantId, limit],
+      )
+      return rows.map((row) => rowToPending<B>(row))
+    },
+
+    async markSent(clientSeq) {
+      await db.exec(
+        'DELETE FROM local_pending_events WHERE tenant_id = ? AND client_seq = ?',
+        [tenantId, clientSeq],
+      )
+    },
+
+    async recordFailure(clientSeq, _reason) {
+      // No status/reason column on the queue table yet (it lands with the
+      // E1.10 write path). The durability guarantee — a failed send keeps the
+      // event — is satisfied by leaving the row untouched. We still confirm the
+      // row exists and belongs to this tenant so a bad client_seq surfaces.
+      await db.exec(
+        'SELECT 1 FROM local_pending_events WHERE tenant_id = ? AND client_seq = ?',
+        [tenantId, clientSeq],
+      )
+    },
+  }
+}

--- a/src/js/web/src/lib/db/repo/pending_queue.ts
+++ b/src/js/web/src/lib/db/repo/pending_queue.ts
@@ -15,8 +15,10 @@
  *     next drain re-sends it — which is the entire durability guarantee
  *     (a failed POST must not lose the event). Persisting a *permanent*
  *     rejection (a status/reason column for the debug surface) requires a DDL
- *     column that lands with E1.10; until then `recordFailure` records the
- *     attempt without mutating the row, keeping it eligible for retry.
+ *     column that lands with E1.10; until then `recordFailure` only asserts the
+ *     row exists (so draining an unknown client_seq is a loud error, not a
+ *     silent no-op) and leaves it eligible for retry. The rejection reason gets
+ *     a parameter once there's a column to store it in.
  */
 
 import type { TenantContext, TenantScoped } from './_tenant'
@@ -47,10 +49,10 @@ export interface PendingQueueRepo<B> {
   /** A row the server accepted; remove it from the queue. */
   markSent(clientSeq: number): Promise<void>
   /**
-   * Report a failed send attempt. Leaves the row queued for retry; the
-   * `reason` is for the caller's logging/debug surface, not persisted yet.
+   * Report a failed send attempt. Leaves the row queued for retry. Throws if
+   * `clientSeq` names no pending row for this tenant.
    */
-  recordFailure(clientSeq: number, reason: string): Promise<void>
+  recordFailure(clientSeq: number): Promise<void>
 }
 
 const DEFAULT_LIMIT = 500
@@ -77,15 +79,18 @@ export function makePendingQueueRepo<B>(
       )
     },
 
-    async recordFailure(clientSeq, _reason) {
-      // No status/reason column on the queue table yet (it lands with the
-      // E1.10 write path). The durability guarantee — a failed send keeps the
-      // event — is satisfied by leaving the row untouched. We still confirm the
-      // row exists and belongs to this tenant so a bad client_seq surfaces.
-      await db.exec(
+    async recordFailure(clientSeq) {
+      // No status/reason column on the queue table yet (it lands with the E1.10
+      // write path), so the durability guarantee — a failed send keeps the
+      // event — is met by leaving the row untouched. Assert it exists, though,
+      // so draining an unknown client_seq surfaces loudly instead of silently.
+      const rows = await db.exec(
         'SELECT 1 FROM local_pending_events WHERE tenant_id = ? AND client_seq = ?',
         [tenantId, clientSeq],
       )
+      if (rows.length === 0) {
+        throw new Error(`recordFailure: unknown client_seq ${clientSeq}`)
+      }
     },
   }
 }

--- a/src/js/web/src/lib/db/repo/schema_projection.ts
+++ b/src/js/web/src/lib/db/repo/schema_projection.ts
@@ -1,0 +1,86 @@
+/**
+ * Read-only views over the server-authoritative schema projection (ADR-008).
+ *
+ * E3/E4 use these to render type-appropriate widgets — the field set and data
+ * types of a given asset/record type. Schema is server-authoritative and never
+ * written locally (it arrives via the schema-change-log fold), so this repo is
+ * read-only. Tombstoned (`active = 0`) rows are included; callers filter at
+ * read time per use case (ADR-008/ADR-009).
+ */
+
+import type { TenantContext, TenantScoped } from './_tenant'
+import type { TypeFieldRow, TypeRow } from './_rows'
+import { parseJson, toBool } from './_sql'
+
+const TYPE_COLUMNS = 'id, name, active'
+const FIELD_COLUMNS = 'id, parent_id, name, data_type, validation, active'
+
+function rowToType<B>(row: unknown[]): TenantScoped<TypeRow, B> {
+  return {
+    id: row[0] as string,
+    name: row[1] as string,
+    active: toBool(row[2]),
+  } as TenantScoped<TypeRow, B>
+}
+
+function rowToField<B>(row: unknown[]): TenantScoped<TypeFieldRow, B> {
+  return {
+    id: row[0] as string,
+    parent_id: row[1] as string,
+    name: row[2] as string,
+    data_type: row[3] as string,
+    validation: parseJson(row[4]),
+    active: toBool(row[5]),
+  } as TenantScoped<TypeFieldRow, B>
+}
+
+export interface SchemaProjectionRepo<B> {
+  listAssetTypes(): Promise<TenantScoped<TypeRow, B>[]>
+  listAssetTypeFields(parentId: string): Promise<TenantScoped<TypeFieldRow, B>[]>
+  listRecordTypes(): Promise<TenantScoped<TypeRow, B>[]>
+  listRecordTypeFields(
+    parentId: string,
+  ): Promise<TenantScoped<TypeFieldRow, B>[]>
+}
+
+export function makeSchemaProjectionRepo<B>(
+  ctx: TenantContext<B>,
+): SchemaProjectionRepo<B> {
+  const { db, tenantId } = ctx
+
+  return {
+    async listAssetTypes() {
+      const rows = await db.exec(
+        `SELECT ${TYPE_COLUMNS} FROM asset_types WHERE tenant_id = ? ORDER BY name`,
+        [tenantId],
+      )
+      return rows.map((row) => rowToType<B>(row))
+    },
+
+    async listAssetTypeFields(parentId) {
+      const rows = await db.exec(
+        `SELECT ${FIELD_COLUMNS} FROM asset_type_fields
+         WHERE tenant_id = ? AND parent_id = ? ORDER BY name`,
+        [tenantId, parentId],
+      )
+      return rows.map((row) => rowToField<B>(row))
+    },
+
+    async listRecordTypes() {
+      const rows = await db.exec(
+        `SELECT ${TYPE_COLUMNS} FROM maintenance_record_types WHERE tenant_id = ? ORDER BY name`,
+        [tenantId],
+      )
+      return rows.map((row) => rowToType<B>(row))
+    },
+
+    async listRecordTypeFields(parentId) {
+      const rows = await db.exec(
+        `SELECT ${FIELD_COLUMNS} FROM maintenance_record_type_fields
+         WHERE tenant_id = ? AND parent_id = ? ORDER BY name`,
+        [tenantId, parentId],
+      )
+      return rows.map((row) => rowToField<B>(row))
+    },
+  }
+}

--- a/src/js/web/tests/component/repo/_fixtures.ts
+++ b/src/js/web/tests/component/repo/_fixtures.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared fixtures for the repository component tests.
+ *
+ * Every test runs against a real in-memory SQLite-WASM DB (no mocks), matching
+ * the server-side discipline. `openLocalDb(..., { memory: true })` gives a
+ * fully-migrated schema on the main thread; the repo set is bound to it via
+ * `withTenant`. Schema-projection and event-log tables have no repo write path,
+ * so tests seed them with direct `exec` against the same handle.
+ */
+import { _resetLocalDbsForTest, openLocalDb } from '../../../src/lib/db/bootstrap'
+import type { DbHandle } from '../../../src/lib/db/bootstrap'
+import { withTenant } from '../../../src/lib/db/repo'
+
+export const TENANT_A = '00000000-0000-0000-0000-00000000000a'
+export const TENANT_B = '00000000-0000-0000-0000-00000000000b'
+
+export const HLC_1 = '2026-06-01T00:00:00.000Z-0000-node'
+export const HLC_2 = '2026-06-01T00:00:01.000Z-0000-node'
+
+export async function freshDb(tenantId: string): Promise<DbHandle> {
+  return openLocalDb(tenantId, { memory: true })
+}
+
+export function resetDbs(): Promise<void> {
+  return _resetLocalDbsForTest()
+}
+
+export { withTenant }
+
+/**
+ * Seed the schema projection rows a data-projection FK needs. The DDL turns on
+ * `PRAGMA foreign_keys`, so an asset insert fails without its `asset_types`
+ * parent row present.
+ */
+export async function seedAssetType(
+  db: DbHandle,
+  tenantId: string,
+  typeId: string,
+  name = 'Pump',
+): Promise<void> {
+  await db.exec(
+    'INSERT INTO asset_types (tenant_id, id, name, active) VALUES (?, ?, ?, 1)',
+    [tenantId, typeId, name],
+  )
+}
+
+export async function seedRecordType(
+  db: DbHandle,
+  tenantId: string,
+  typeId: string,
+  name = 'Inspection',
+): Promise<void> {
+  await db.exec(
+    'INSERT INTO maintenance_record_types (tenant_id, id, name, active) VALUES (?, ?, ?, 1)',
+    [tenantId, typeId, name],
+  )
+}

--- a/src/js/web/tests/component/repo/asset.test.ts
+++ b/src/js/web/tests/component/repo/asset.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { DbHandle } from '../../../src/lib/db/bootstrap'
+import {
+  HLC_1,
+  HLC_2,
+  TENANT_A,
+  freshDb,
+  resetDbs,
+  seedAssetType,
+  withTenant,
+} from './_fixtures'
+
+const TYPE_PUMP = '00000000-0000-0000-0000-0000000000a1'
+const ASSET_1 = '00000000-0000-0000-0000-0000000000b1'
+const ASSET_2 = '00000000-0000-0000-0000-0000000000b2'
+
+function draft(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    type_id: TYPE_PUMP,
+    properties: { name: 'Pump 1' },
+    deleted: false,
+    row_state_hlc: HLC_1,
+    ...overrides,
+  }
+}
+
+describe('assetRepo', () => {
+  let db: DbHandle
+  let repo: ReturnType<typeof withTenant>['assets']
+
+  beforeEach(async () => {
+    db = await freshDb(TENANT_A)
+    await seedAssetType(db, TENANT_A, TYPE_PUMP)
+    repo = withTenant(db, TENANT_A).assets
+  })
+
+  afterEach(resetDbs)
+
+  it('upserts a new asset and reads it back via getById', async () => {
+    await repo.upsert(draft(ASSET_1))
+
+    const row = await repo.getById(ASSET_1)
+    expect(row).toMatchObject({
+      id: ASSET_1,
+      type_id: TYPE_PUMP,
+      properties: { name: 'Pump 1' },
+      deleted: false,
+      row_state_hlc: HLC_1,
+    })
+  })
+
+  it('returns null from getById for an unknown id', async () => {
+    expect(await repo.getById(ASSET_1)).toBeNull()
+  })
+
+  it('upsert is idempotent on the primary key (overwrites)', async () => {
+    await repo.upsert(draft(ASSET_1))
+    await repo.upsert(
+      draft(ASSET_1, { properties: { name: 'Renamed' }, row_state_hlc: HLC_2 }),
+    )
+
+    const row = await repo.getById(ASSET_1)
+    expect(row?.properties).toEqual({ name: 'Renamed' })
+    expect(row?.row_state_hlc).toBe(HLC_2)
+  })
+
+  it('listByType returns only assets of the given type, in id order', async () => {
+    await repo.upsert(draft(ASSET_2))
+    await repo.upsert(draft(ASSET_1))
+
+    const rows = await repo.listByType(TYPE_PUMP)
+    expect(rows.map((r) => r.id)).toEqual([ASSET_1, ASSET_2])
+  })
+
+  it('archive sets deleted and restore clears it', async () => {
+    await repo.upsert(draft(ASSET_1))
+
+    await repo.archive(ASSET_1, HLC_2)
+    expect((await repo.getById(ASSET_1))?.deleted).toBe(true)
+    expect((await repo.getById(ASSET_1))?.row_state_hlc).toBe(HLC_2)
+
+    await repo.restore(ASSET_1, HLC_2)
+    expect((await repo.getById(ASSET_1))?.deleted).toBe(false)
+  })
+
+  it('delete removes the row', async () => {
+    await repo.upsert(draft(ASSET_1))
+    await repo.delete(ASSET_1)
+
+    expect(await repo.getById(ASSET_1)).toBeNull()
+  })
+})

--- a/src/js/web/tests/component/repo/cross_tenant.test.ts
+++ b/src/js/web/tests/component/repo/cross_tenant.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Paired cross-tenant isolation, mirroring the server's
+ * `tests/schema/test_cross_tenant_isolation.py` discipline: seed equivalent
+ * rows under two tenant ids in the *same* DB and assert each tenant's repo
+ * sees only its own.
+ *
+ * The local app opens one tenant's DB file at a time, but the `tenant_id`
+ * column is carried on every row for wire/fold parity (see `ddl.ts`); these
+ * tests prove the repo's WHERE/VALUES pinning is correct regardless, which is
+ * the property E3/E4 rely on.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { DbHandle } from '../../../src/lib/db/bootstrap'
+import {
+  HLC_1,
+  TENANT_A,
+  TENANT_B,
+  freshDb,
+  resetDbs,
+  seedAssetType,
+  withTenant,
+} from './_fixtures'
+
+const TYPE_PUMP = '00000000-0000-0000-0000-0000000000a1'
+const ASSET_A = '00000000-0000-0000-0000-0000000000aa'
+const ASSET_B = '00000000-0000-0000-0000-0000000000bb'
+const FIELD_NAME = '00000000-0000-0000-0000-0000000000d1'
+
+describe('cross-tenant isolation', () => {
+  let db: DbHandle
+
+  beforeEach(async () => {
+    // One physical DB, two tenants seeded with equivalent rows.
+    db = await freshDb(TENANT_A)
+    await seedAssetType(db, TENANT_A, TYPE_PUMP)
+    await seedAssetType(db, TENANT_B, TYPE_PUMP)
+
+    const a = withTenant(db, TENANT_A)
+    const b = withTenant(db, TENANT_B)
+    await a.assets.upsert({
+      id: ASSET_A,
+      type_id: TYPE_PUMP,
+      properties: { name: 'A' },
+      deleted: false,
+      row_state_hlc: HLC_1,
+    })
+    await b.assets.upsert({
+      id: ASSET_B,
+      type_id: TYPE_PUMP,
+      properties: { name: 'B' },
+      deleted: false,
+      row_state_hlc: HLC_1,
+    })
+    await a.assetFieldValues.upsert({
+      asset_id: ASSET_A,
+      field_id: FIELD_NAME,
+      value_json: 'A',
+      hlc: HLC_1,
+    })
+    await b.assetFieldValues.upsert({
+      asset_id: ASSET_B,
+      field_id: FIELD_NAME,
+      value_json: 'B',
+      hlc: HLC_1,
+    })
+  })
+
+  afterEach(resetDbs)
+
+  it('listByType returns only the calling tenant rows', async () => {
+    const a = withTenant(db, TENANT_A)
+    const b = withTenant(db, TENANT_B)
+
+    expect((await a.assets.listByType(TYPE_PUMP)).map((r) => r.id)).toEqual([
+      ASSET_A,
+    ])
+    expect((await b.assets.listByType(TYPE_PUMP)).map((r) => r.id)).toEqual([
+      ASSET_B,
+    ])
+  })
+
+  it('getById cannot reach across tenants', async () => {
+    const a = withTenant(db, TENANT_A)
+    const b = withTenant(db, TENANT_B)
+
+    expect(await a.assets.getById(ASSET_B)).toBeNull()
+    expect(await b.assets.getById(ASSET_A)).toBeNull()
+  })
+
+  it('field-value reads are tenant-scoped', async () => {
+    const a = withTenant(db, TENANT_A)
+    const b = withTenant(db, TENANT_B)
+
+    expect(await a.assetFieldValues.listByAsset(ASSET_B)).toEqual([])
+    expect((await b.assetFieldValues.listByAsset(ASSET_B))[0].value_json).toBe(
+      'B',
+    )
+  })
+
+  it('a write under tenant A does not appear under tenant B', async () => {
+    const a = withTenant(db, TENANT_A)
+    const b = withTenant(db, TENANT_B)
+
+    await a.assets.archive(ASSET_A, HLC_1)
+    // B's equivalent row is untouched.
+    expect((await b.assets.getById(ASSET_B))?.deleted).toBe(false)
+  })
+})

--- a/src/js/web/tests/component/repo/field_values.test.ts
+++ b/src/js/web/tests/component/repo/field_values.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { DbHandle } from '../../../src/lib/db/bootstrap'
+import {
+  HLC_1,
+  HLC_2,
+  TENANT_A,
+  freshDb,
+  resetDbs,
+  seedAssetType,
+  seedRecordType,
+  withTenant,
+} from './_fixtures'
+
+const TYPE_PUMP = '00000000-0000-0000-0000-0000000000a1'
+const TYPE_INSPECT = '00000000-0000-0000-0000-0000000000a2'
+const ASSET_1 = '00000000-0000-0000-0000-0000000000b1'
+const RECORD_1 = '00000000-0000-0000-0000-0000000000c1'
+const FIELD_NAME = '00000000-0000-0000-0000-0000000000d1'
+const FIELD_SERIAL = '00000000-0000-0000-0000-0000000000d2'
+
+describe('assetFieldValueRepo', () => {
+  let db: DbHandle
+  let repos: ReturnType<typeof withTenant>
+
+  beforeEach(async () => {
+    db = await freshDb(TENANT_A)
+    await seedAssetType(db, TENANT_A, TYPE_PUMP)
+    repos = withTenant(db, TENANT_A)
+    await repos.assets.upsert({
+      id: ASSET_1,
+      type_id: TYPE_PUMP,
+      properties: {},
+      deleted: false,
+      row_state_hlc: HLC_1,
+    })
+  })
+
+  afterEach(resetDbs)
+
+  it('upserts and lists field values for an asset, ordered by field id', async () => {
+    await repos.assetFieldValues.upsert({
+      asset_id: ASSET_1,
+      field_id: FIELD_SERIAL,
+      value_json: 'SN-9',
+      hlc: HLC_1,
+    })
+    await repos.assetFieldValues.upsert({
+      asset_id: ASSET_1,
+      field_id: FIELD_NAME,
+      value_json: 'Pump 1',
+      hlc: HLC_1,
+    })
+
+    const rows = await repos.assetFieldValues.listByAsset(ASSET_1)
+    expect(rows.map((r) => r.field_id)).toEqual([FIELD_NAME, FIELD_SERIAL])
+    expect(rows.map((r) => r.value_json)).toEqual(['Pump 1', 'SN-9'])
+  })
+
+  it('upsert overwrites an existing field value (LWW slot)', async () => {
+    await repos.assetFieldValues.upsert({
+      asset_id: ASSET_1,
+      field_id: FIELD_NAME,
+      value_json: 'Old',
+      hlc: HLC_1,
+    })
+    await repos.assetFieldValues.upsert({
+      asset_id: ASSET_1,
+      field_id: FIELD_NAME,
+      value_json: 'New',
+      hlc: HLC_2,
+    })
+
+    const rows = await repos.assetFieldValues.listByAsset(ASSET_1)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ value_json: 'New', hlc: HLC_2 })
+  })
+
+  it('clear writes a JSON null, keeping the row present', async () => {
+    await repos.assetFieldValues.upsert({
+      asset_id: ASSET_1,
+      field_id: FIELD_NAME,
+      value_json: 'Pump 1',
+      hlc: HLC_1,
+    })
+    await repos.assetFieldValues.clear(ASSET_1, FIELD_NAME, HLC_2)
+
+    const rows = await repos.assetFieldValues.listByAsset(ASSET_1)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ value_json: null, hlc: HLC_2 })
+  })
+
+  it('preserves object value_json round-trip', async () => {
+    await repos.assetFieldValues.upsert({
+      asset_id: ASSET_1,
+      field_id: FIELD_NAME,
+      value_json: { nested: [1, 2, 3] },
+      hlc: HLC_1,
+    })
+    const rows = await repos.assetFieldValues.listByAsset(ASSET_1)
+    expect(rows[0].value_json).toEqual({ nested: [1, 2, 3] })
+  })
+})
+
+describe('maintenanceRecordFieldValueRepo', () => {
+  let db: DbHandle
+  let repos: ReturnType<typeof withTenant>
+
+  beforeEach(async () => {
+    db = await freshDb(TENANT_A)
+    await seedAssetType(db, TENANT_A, TYPE_PUMP)
+    await seedRecordType(db, TENANT_A, TYPE_INSPECT)
+    repos = withTenant(db, TENANT_A)
+    await repos.assets.upsert({
+      id: ASSET_1,
+      type_id: TYPE_PUMP,
+      properties: {},
+      deleted: false,
+      row_state_hlc: HLC_1,
+    })
+    await repos.maintenanceRecords.upsert({
+      id: RECORD_1,
+      type_id: TYPE_INSPECT,
+      asset_id: ASSET_1,
+      properties: {},
+      deleted: false,
+      row_state_hlc: HLC_1,
+    })
+  })
+
+  afterEach(resetDbs)
+
+  it('upserts, lists and clears record field values', async () => {
+    await repos.maintenanceRecordFieldValues.upsert({
+      maintenance_record_id: RECORD_1,
+      field_id: FIELD_NAME,
+      value_json: 'Quarterly',
+      hlc: HLC_1,
+    })
+
+    let rows = await repos.maintenanceRecordFieldValues.listByRecord(RECORD_1)
+    expect(rows[0]).toMatchObject({ value_json: 'Quarterly' })
+
+    await repos.maintenanceRecordFieldValues.clear(RECORD_1, FIELD_NAME, HLC_2)
+    rows = await repos.maintenanceRecordFieldValues.listByRecord(RECORD_1)
+    expect(rows[0]).toMatchObject({ value_json: null, hlc: HLC_2 })
+  })
+})

--- a/src/js/web/tests/component/repo/maintenance_record.test.ts
+++ b/src/js/web/tests/component/repo/maintenance_record.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { DbHandle } from '../../../src/lib/db/bootstrap'
+import {
+  HLC_1,
+  HLC_2,
+  TENANT_A,
+  freshDb,
+  resetDbs,
+  seedAssetType,
+  seedRecordType,
+  withTenant,
+} from './_fixtures'
+
+const TYPE_PUMP = '00000000-0000-0000-0000-0000000000a1'
+const TYPE_INSPECT = '00000000-0000-0000-0000-0000000000a2'
+const ASSET_1 = '00000000-0000-0000-0000-0000000000b1'
+const RECORD_1 = '00000000-0000-0000-0000-0000000000c1'
+const RECORD_2 = '00000000-0000-0000-0000-0000000000c2'
+
+describe('maintenanceRecordRepo', () => {
+  let db: DbHandle
+  let repos: ReturnType<typeof withTenant>
+
+  function draft(id: string, overrides: Record<string, unknown> = {}) {
+    return {
+      id,
+      type_id: TYPE_INSPECT,
+      asset_id: ASSET_1,
+      properties: { name: 'Q1 inspection' },
+      deleted: false,
+      row_state_hlc: HLC_1,
+      ...overrides,
+    }
+  }
+
+  beforeEach(async () => {
+    db = await freshDb(TENANT_A)
+    await seedAssetType(db, TENANT_A, TYPE_PUMP)
+    await seedRecordType(db, TENANT_A, TYPE_INSPECT)
+    repos = withTenant(db, TENANT_A)
+    await repos.assets.upsert({
+      id: ASSET_1,
+      type_id: TYPE_PUMP,
+      properties: {},
+      deleted: false,
+      row_state_hlc: HLC_1,
+    })
+  })
+
+  afterEach(resetDbs)
+
+  it('upserts a record carrying its parent asset id and reads it back', async () => {
+    await repos.maintenanceRecords.upsert(draft(RECORD_1))
+
+    const row = await repos.maintenanceRecords.getById(RECORD_1)
+    expect(row).toMatchObject({
+      id: RECORD_1,
+      type_id: TYPE_INSPECT,
+      asset_id: ASSET_1,
+      properties: { name: 'Q1 inspection' },
+      deleted: false,
+    })
+  })
+
+  it('getById returns null for an unknown id', async () => {
+    expect(await repos.maintenanceRecords.getById(RECORD_1)).toBeNull()
+  })
+
+  it('listByType returns only records of the type, id-ordered', async () => {
+    await repos.maintenanceRecords.upsert(draft(RECORD_2))
+    await repos.maintenanceRecords.upsert(draft(RECORD_1))
+
+    const rows = await repos.maintenanceRecords.listByType(TYPE_INSPECT)
+    expect(rows.map((r) => r.id)).toEqual([RECORD_1, RECORD_2])
+  })
+
+  it('archive, restore and delete behave like the asset repo', async () => {
+    await repos.maintenanceRecords.upsert(draft(RECORD_1))
+
+    await repos.maintenanceRecords.archive(RECORD_1, HLC_2)
+    expect((await repos.maintenanceRecords.getById(RECORD_1))?.deleted).toBe(
+      true,
+    )
+
+    await repos.maintenanceRecords.restore(RECORD_1, HLC_2)
+    expect((await repos.maintenanceRecords.getById(RECORD_1))?.deleted).toBe(
+      false,
+    )
+
+    await repos.maintenanceRecords.delete(RECORD_1)
+    expect(await repos.maintenanceRecords.getById(RECORD_1)).toBeNull()
+  })
+})

--- a/src/js/web/tests/component/repo/schema_event_pending.test.ts
+++ b/src/js/web/tests/component/repo/schema_event_pending.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { DbHandle } from '../../../src/lib/db/bootstrap'
+import { HLC_1, HLC_2, TENANT_A, freshDb, resetDbs, withTenant } from './_fixtures'
+
+const TYPE_PUMP = '00000000-0000-0000-0000-0000000000a1'
+const FIELD_NAME = '00000000-0000-0000-0000-0000000000d1'
+const ASSET_1 = '00000000-0000-0000-0000-0000000000b1'
+
+describe('schemaProjectionRepo', () => {
+  let db: DbHandle
+  let repos: ReturnType<typeof withTenant>
+
+  beforeEach(async () => {
+    db = await freshDb(TENANT_A)
+    await db.exec(
+      'INSERT INTO asset_types (tenant_id, id, name, active) VALUES (?, ?, ?, 0)',
+      [TENANT_A, TYPE_PUMP, 'Pump'],
+    )
+    await db.exec(
+      `INSERT INTO asset_type_fields
+         (tenant_id, id, parent_id, name, data_type, validation, active)
+       VALUES (?, ?, ?, ?, ?, ?, 1)`,
+      [TENANT_A, FIELD_NAME, TYPE_PUMP, 'name', 'text', '{"required":true}'],
+    )
+    repos = withTenant(db, TENANT_A)
+  })
+
+  afterEach(resetDbs)
+
+  it('lists asset types including tombstoned (active=false) rows', async () => {
+    const types = await repos.schema.listAssetTypes()
+    expect(types).toEqual([{ id: TYPE_PUMP, name: 'Pump', active: false }])
+  })
+
+  it('lists fields for a type with parsed validation JSON', async () => {
+    const fields = await repos.schema.listAssetTypeFields(TYPE_PUMP)
+    expect(fields).toEqual([
+      {
+        id: FIELD_NAME,
+        parent_id: TYPE_PUMP,
+        name: 'name',
+        data_type: 'text',
+        validation: { required: true },
+        active: true,
+      },
+    ])
+  })
+
+  it('returns empty arrays for record types with no rows', async () => {
+    expect(await repos.schema.listRecordTypes()).toEqual([])
+    expect(await repos.schema.listRecordTypeFields(TYPE_PUMP)).toEqual([])
+  })
+})
+
+describe('eventLogRepo', () => {
+  let db: DbHandle
+  let repos: ReturnType<typeof withTenant>
+
+  beforeEach(async () => {
+    db = await freshDb(TENANT_A)
+    for (const [seq, hlc] of [
+      [1, HLC_1],
+      [2, HLC_2],
+    ] as const) {
+      await db.exec(
+        `INSERT INTO event_log
+           (seq, tenant_id, hlc, schema_version, table_name, type_id, entity_id, op, value_json)
+         VALUES (?, ?, ?, 1, 'assets', ?, ?, 'CREATE', ?)`,
+        [seq, TENANT_A, hlc, TYPE_PUMP, ASSET_1, '{"k":1}'],
+      )
+    }
+    repos = withTenant(db, TENANT_A)
+  })
+
+  afterEach(resetDbs)
+
+  it('lists events after a cursor in seq order with parsed value_json', async () => {
+    const events = await repos.events.listSince(0)
+    expect(events.map((e) => e.seq)).toEqual([1, 2])
+    expect(events[0].value_json).toEqual({ k: 1 })
+  })
+
+  it('honours the exclusive cursor', async () => {
+    const events = await repos.events.listSince(1)
+    expect(events.map((e) => e.seq)).toEqual([2])
+  })
+
+  it('getBySeq returns one row or null', async () => {
+    expect((await repos.events.getBySeq(2))?.hlc).toBe(HLC_2)
+    expect(await repos.events.getBySeq(99)).toBeNull()
+  })
+})
+
+describe('pendingQueueRepo', () => {
+  let db: DbHandle
+  let repos: ReturnType<typeof withTenant>
+
+  async function enqueue(hlc: string): Promise<number> {
+    const rows = await db.exec(
+      `INSERT INTO local_pending_events
+         (tenant_id, hlc, schema_version, table_name, type_id, entity_id, op, value_json)
+       VALUES (?, ?, 1, 'assets', ?, ?, 'CREATE', '{}')
+       RETURNING client_seq`,
+      [TENANT_A, hlc, TYPE_PUMP, ASSET_1],
+    )
+    return rows[0][0] as number
+  }
+
+  beforeEach(async () => {
+    db = await freshDb(TENANT_A)
+    repos = withTenant(db, TENANT_A)
+  })
+
+  afterEach(resetDbs)
+
+  it('lists pending rows in hlc (send) order', async () => {
+    await enqueue(HLC_2)
+    await enqueue(HLC_1)
+
+    const pending = await repos.pending.listPending()
+    expect(pending.map((p) => p.hlc)).toEqual([HLC_1, HLC_2])
+  })
+
+  it('markSent removes the row from the queue', async () => {
+    const seq = await enqueue(HLC_1)
+    await repos.pending.markSent(seq)
+
+    expect(await repos.pending.listPending()).toEqual([])
+  })
+
+  it('recordFailure leaves the row queued for retry', async () => {
+    const seq = await enqueue(HLC_1)
+    await repos.pending.recordFailure(seq, 'network down')
+
+    const pending = await repos.pending.listPending()
+    expect(pending.map((p) => p.client_seq)).toEqual([seq])
+  })
+})

--- a/src/js/web/tests/component/repo/schema_event_pending.test.ts
+++ b/src/js/web/tests/component/repo/schema_event_pending.test.ts
@@ -131,9 +131,15 @@ describe('pendingQueueRepo', () => {
 
   it('recordFailure leaves the row queued for retry', async () => {
     const seq = await enqueue(HLC_1)
-    await repos.pending.recordFailure(seq, 'network down')
+    await repos.pending.recordFailure(seq)
 
     const pending = await repos.pending.listPending()
     expect(pending.map((p) => p.client_seq)).toEqual([seq])
+  })
+
+  it('recordFailure throws on an unknown client_seq', async () => {
+    await expect(repos.pending.recordFailure(999_999)).rejects.toThrow(
+      /unknown client_seq/,
+    )
   })
 })

--- a/src/js/web/tests/component/repo/tenant_safety.test-d.ts
+++ b/src/js/web/tests/component/repo/tenant_safety.test-d.ts
@@ -1,0 +1,50 @@
+/**
+ * Compile-time tenant-safety check.
+ *
+ * The acceptance criterion is that the type signatures *forbid* handing a row
+ * read from one tenant's repo into another tenant's `upsert`. This file proves
+ * it: each `@ts-expect-error` line MUST fail to type-check, so `svelte-check` /
+ * `tsc` (run by `npm run check` and CI's typecheck-js job) goes red if the
+ * brand ever stops working. There are no runtime assertions — the type checker
+ * is the assertion.
+ *
+ * The brands `'a'` / `'b'` are phantom string-literal tenant tags; in real code
+ * the call site picks any two distinct brands for the two tenants it juggles.
+ */
+import { withTenant } from '../../../src/lib/db/repo'
+import type { DbHandle } from '../../../src/lib/db/bootstrap'
+
+declare const db: DbHandle
+
+const a = withTenant<'a'>(db, 'tenant-a')
+const b = withTenant<'b'>(db, 'tenant-b')
+
+async function crossTenantWritesAreCompileErrors(): Promise<void> {
+  const rowFromA = await a.assets.getById('asset-1')
+  if (rowFromA === null) {
+    return
+  }
+
+  // A row read under brand 'a' is `TenantScoped<AssetRow, 'a'>`; B's upsert
+  // wants `Writable<AssetDraft, 'b'>`. The brands disagree -> type error.
+  // @ts-expect-error cross-tenant upsert must not type-check
+  await b.assets.upsert(rowFromA)
+
+  // Same guarantee for field values.
+  const fvFromA = await a.assetFieldValues.listByAsset('asset-1')
+  // @ts-expect-error cross-tenant field-value upsert must not type-check
+  await b.assetFieldValues.upsert(fvFromA[0])
+
+  // And maintenance records.
+  const recFromA = await a.maintenanceRecords.getById('rec-1')
+  if (recFromA !== null) {
+    // @ts-expect-error cross-tenant record upsert must not type-check
+    await b.maintenanceRecords.upsert(recFromA)
+  }
+
+  // The matching same-tenant write DOES type-check (no @ts-expect-error).
+  await a.assets.upsert(rowFromA)
+}
+
+// Reference the function so `noUnusedLocals` stays quiet without running it.
+export const _typeChecks = crossTenantWritesAreCompileErrors


### PR DESCRIPTION
## Summary

- Hand-rolled inline-SQL repository façade over the local SQLite-WASM DB (the approach the E1.4 spike chose; query builders cost too much bundle weight for a local-first client). Lives under `src/js/web/src/lib/db/repo/`.
- Surfaces shipped: `assetRepo` (listByType/getById/upsert/archive/restore/delete), `assetFieldValueRepo` (listByAsset/upsert/clear), `maintenanceRecordRepo` (same shape as assets), `maintenanceRecordFieldValueRepo` (listByRecord/upsert/clear), `schemaProjectionRepo` (read-only type/field views), `eventLogRepo` (read-only listSince/getBySeq), `pendingQueueRepo` (listPending/markSent/recordFailure).
- `withTenant(db, tenantId)` is the single entry point — it pins `tenant_id` into every WHERE/VALUES so a repo bound to tenant A never reads or writes tenant B's rows.

### Compile-time tenant safety

`withTenant<B>(...)` brands the repo set (and every row it returns) with a phantom tenant type `B` (`TenantScoped<T, B> = T & { readonly [BRAND]: B }`, where `BRAND` is a `declare`d unique symbol — zero runtime cost). `upsert` accepts `Writable<T, B> = T & { readonly [BRAND]?: B }`: a freshly-built plain draft (no brand) type-checks for either tenant, but a row read from tenant A's repo carries `[BRAND]: 'a'`, which is **not** assignable to tenant B's `[BRAND]?: 'b'`. So `b.assets.upsert(rowReadFromA)` is a type error:

```
Type '"a"' is not assignable to type '"b"'.
```

`tests/component/repo/tenant_safety.test-d.ts` pins this with `@ts-expect-error` lines that CI's `typecheck-js` job (`svelte-check`) enforces — if the brand ever stops working, an unused-directive error turns the build red. Verified by removing a directive and observing the exact diagnostic above.

## Test plan

- [x] `npm run check` (svelte-check + tsc) — 0 errors, including the `.test-d.ts` brand enforcement.
- [x] `npm run test` — 137 passed (28 new repo tests against a **real in-memory SQLite-WASM** DB, no mocks).
- [x] Paired cross-tenant runtime isolation (`cross_tenant.test.ts`): equivalent rows seeded under two tenant ids in one DB; each tenant's repo sees only its own (list/get/field-values/writes).
- [x] `npm run test:e2e` — 5 passed, 3 skipped (pre-existing API-dependent).
- [x] `just coverage` + `just ratchet-update` — JS line 73→75, branch 56→58; ratchet green. Python untouched.

### Parallel-work note

Stayed inside the E1.9 boundary: only `src/lib/db/repo/**` and `tests/component/repo/**` are added. Did **not** touch `fold.ts`, `sync/`, `ddl.ts`, `migrations.ts`, or `types.ts` — repo-local row types live in `repo/_rows.ts` to avoid colliding with E1.6 (#145). The only shared edit is `.coverage-ratchet.json` (expected; reconcile on second merge).

`pendingQueueRepo.recordFailure` leaves the row queued for retry (the durability guarantee) without mutating it — a persistent status/reason column is E1.10's DDL to add and is out of this issue's boundary.

Closes #148